### PR TITLE
Implement Native Trino Ion PageSource and FileWriter

### DIFF
--- a/lib/trino-hive-formats/pom.xml
+++ b/lib/trino-hive-formats/pom.xml
@@ -17,6 +17,13 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>com.amazon.ion</groupId>
+            <artifactId>ion-java</artifactId>
+            <version>1.11.9</version>
+        </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveClassNames.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/HiveClassNames.java
@@ -27,6 +27,10 @@ public final class HiveClassNames
     public static final String HUDI_PARQUET_REALTIME_INPUT_FORMAT = "org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat";
     public static final String HUDI_INPUT_FORMAT = "com.uber.hoodie.hadoop.HoodieInputFormat";
     public static final String HUDI_REALTIME_INPUT_FORMAT = "com.uber.hoodie.hadoop.realtime.HoodieRealtimeInputFormat";
+    public static final String ION_SERDE_CLASS = "com.amazon.ionhiveserde.IonHiveSerDe";
+    public static final String ION_INPUT_FORMAT = "com.amazon.ionhiveserde.formats.IonInputFormat";
+    public static final String ION_OUTPUT_FORMAT = "com.amazon.ionhiveserde.formats.IonOutputFormat";
+
     public static final String JSON_SERDE_CLASS = "org.apache.hive.hcatalog.data.JsonSerDe";
     public static final String LEGACY_JSON_SERDE_CLASS = "org.apache.hadoop.hive.serde2.JsonSerDe";
     public static final String OPENX_JSON_SERDE_CLASS = "org.openx.data.jsonserde.JsonSerDe";

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoder.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoder.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.ion;
+
+import com.amazon.ion.IonException;
+import com.amazon.ion.IonReader;
+import io.trino.spi.PageBuilder;
+
+public interface IonDecoder
+{
+    /**
+     * Reads the _current_ top-level-value from the IonReader.
+     * <p>
+     * Expects that the calling code has called IonReader.getNext()
+     * to position the reader at the value to be decoded.
+     */
+    void decode(IonReader reader, PageBuilder builder)
+            throws IonException;
+}

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoder.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoder.java
@@ -22,7 +22,7 @@ public interface IonDecoder
     /**
      * Reads the _current_ top-level-value from the IonReader.
      * <p>
-     * Expects that the calling code has called IonReader.getNext()
+     * Expects that the calling code has called IonReader.next()
      * to position the reader at the value to be decoded.
      */
     void decode(IonReader reader, PageBuilder builder)

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.ion;
+
+import com.amazon.ion.IonException;
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slices;
+import io.trino.hive.formats.line.Column;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.ArrayBlockBuilder;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.IntFunction;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class IonDecoderFactory
+{
+    private IonDecoderFactory() {}
+
+    /**
+     * Builds a decoder for the given columns.
+     * <p>
+     * The decoder expects to decode the _current_ Ion Value.
+     * It also expects that the calling code will manage the PageBuilder.
+     * <p>
+     */
+    public static IonDecoder buildDecoder(List<Column> columns)
+    {
+        return RowDecoder.forFields(
+                columns.stream()
+                        .map(c -> new RowType.Field(Optional.of(c.name()), c.type()))
+                        .toList());
+    }
+
+    private interface BlockDecoder
+    {
+        void decode(IonReader reader, BlockBuilder builder);
+    }
+
+    private static BlockDecoder decoderForType(Type type)
+    {
+        return switch (type) {
+            case TinyintType _ -> wrapDecoder(byteDecoder, IonType.INT);
+            case SmallintType _ -> wrapDecoder(shortDecoder, IonType.INT);
+            case IntegerType _ -> wrapDecoder(intDecoder, IonType.INT);
+            case BigintType _ -> wrapDecoder(longDecoder, IonType.INT);
+            case RealType _ -> wrapDecoder(realDecoder, IonType.FLOAT);
+            case DoubleType _ -> wrapDecoder(floatDecoder, IonType.FLOAT);
+            case BooleanType _ -> wrapDecoder(boolDecoder, IonType.BOOL);
+            case TimestampType t -> wrapDecoder(timestampDecoder(t), IonType.TIMESTAMP);
+            case DecimalType t -> wrapDecoder(decimalDecoder(t), IonType.DECIMAL);
+            case VarcharType _, CharType _ -> wrapDecoder(stringDecoder, IonType.STRING, IonType.SYMBOL);
+            case VarbinaryType _ -> wrapDecoder(binaryDecoder, IonType.BLOB, IonType.CLOB);
+            case RowType r -> wrapDecoder(RowDecoder.forFields(r.getFields()), IonType.STRUCT);
+            case ArrayType a -> wrapDecoder(new ArrayDecoder(decoderForType(a.getElementType())), IonType.LIST, IonType.SEXP);
+            default -> throw new IllegalArgumentException(String.format("Unsupported type: %s", type));
+        };
+    }
+
+    /**
+     * Wraps decoders for common handling logic.
+     * <p>
+     * Handles un-typed and correctly typed null values.
+     * Throws for mistyped values, whether null or not.
+     * Delegates to Decoder for correctly-typed, non-null values.
+     * <p>
+     * This code treats all values as nullable.
+     */
+    private static BlockDecoder wrapDecoder(BlockDecoder decoder, IonType... allowedTypes)
+    {
+        final Set<IonType> allowedWithNull = new HashSet<>(Arrays.asList(allowedTypes));
+        allowedWithNull.add(IonType.NULL);
+
+        return (reader, builder) -> {
+            final IonType type = reader.getType();
+            if (!allowedWithNull.contains(type)) {
+                final String expected = allowedWithNull.stream().map(IonType::name).collect(Collectors.joining(", "));
+                throw new IonException(String.format("Encountered value with IonType: %s, required one of %s ", type, expected));
+            }
+            if (reader.isNullValue()) {
+                builder.appendNull();
+            }
+            else {
+                decoder.decode(reader, builder);
+            }
+        };
+    }
+
+    /**
+     * Class is both the Top-Level-Value Decoder and the Row Decoder for nested
+     * structs.
+     */
+    private record RowDecoder(Map<String, Integer> fieldPositions, List<BlockDecoder> fieldDecoders)
+            implements IonDecoder, BlockDecoder
+    {
+        private static RowDecoder forFields(List<RowType.Field> fields)
+        {
+            ImmutableList.Builder<BlockDecoder> decoderBuilder = ImmutableList.builder();
+            ImmutableMap.Builder<String, Integer> fieldPositionBuilder = ImmutableMap.builder();
+            IntStream.range(0, fields.size())
+                    .forEach(position -> {
+                        RowType.Field field = fields.get(position);
+                        decoderBuilder.add(decoderForType(field.getType()));
+                        fieldPositionBuilder.put(field.getName().get(), position);
+                    });
+
+            return new RowDecoder(fieldPositionBuilder.buildOrThrow(), decoderBuilder.build());
+        }
+
+        @Override
+        public void decode(IonReader ionReader, PageBuilder pageBuilder)
+        {
+            // todo: also map lists?
+            if (ionReader.getType() != IonType.STRUCT) {
+                throw new IonException("RowType must be Structs! Encountered: " + ionReader.getType());
+            }
+            if (ionReader.isNullValue()) {
+                // todo: is this an error?
+                throw new IonException("Top Level Values must not be null!");
+            }
+            decode(ionReader, pageBuilder::getBlockBuilder);
+        }
+
+        @Override
+        public void decode(IonReader ionReader, BlockBuilder blockBuilder)
+        {
+            ((RowBlockBuilder) blockBuilder)
+                    .buildEntry(fieldBuilders -> decode(ionReader, fieldBuilders::get));
+        }
+
+        // assumes that the reader is positioned on a non-null struct value
+        private void decode(IonReader ionReader, IntFunction<BlockBuilder> blockSelector)
+        {
+            boolean[] encountered = new boolean[fieldDecoders.size()];
+            ionReader.stepIn();
+
+            while (ionReader.next() != null) {
+                // todo: case insensitivity?
+                final Integer fieldIndex = fieldPositions.get(ionReader.getFieldName());
+                if (fieldIndex == null) {
+                    continue;
+                }
+                final BlockBuilder blockBuilder = blockSelector.apply(fieldIndex);
+                if (encountered[fieldIndex]) {
+                    blockBuilder.resetTo(blockBuilder.getPositionCount() - 1);
+                }
+                else {
+                    encountered[fieldIndex] = true;
+                }
+                fieldDecoders.get(fieldIndex).decode(ionReader, blockBuilder);
+            }
+
+            for (int i = 0; i < encountered.length; i++) {
+                if (!encountered[i]) {
+                    blockSelector.apply(i).appendNull();
+                }
+            }
+
+            ionReader.stepOut();
+        }
+    }
+
+    private record ArrayDecoder(BlockDecoder elementDecoder)
+            implements BlockDecoder
+    {
+        @Override
+        public void decode(IonReader ionReader, BlockBuilder blockBuilder)
+        {
+            ((ArrayBlockBuilder) blockBuilder)
+                    .buildEntry(elementBuilder -> {
+                        ionReader.stepIn();
+                        while (ionReader.next() != null) {
+                            elementDecoder.decode(ionReader, elementBuilder);
+                        }
+                        ionReader.stepOut();
+                    });
+        }
+    }
+
+    private static BlockDecoder timestampDecoder(TimestampType type)
+    {
+        // todo: no attempt is made at handling offsets or lack thereof
+        if (type.isShort()) {
+            return (reader, builder) -> {
+                long micros = reader.timestampValue().getDecimalMillis()
+                        .setScale(type.getPrecision() - 3, RoundingMode.HALF_EVEN)
+                        .movePointRight(3)
+                        .longValue();
+                type.writeLong(builder, micros);
+            };
+        }
+        else {
+            return (reader, builder) -> {
+                BigDecimal decimalMicros = reader.timestampValue().getDecimalMillis()
+                        .movePointRight(3);
+                BigDecimal subMicrosFrac = decimalMicros.remainder(BigDecimal.ONE)
+                        .movePointRight(6);
+                type.writeObject(builder, new LongTimestamp(decimalMicros.longValue(), subMicrosFrac.intValue()));
+            };
+        }
+    }
+
+    private static BlockDecoder decimalDecoder(DecimalType type)
+    {
+        if (type.isShort()) {
+            return (reader, builder) -> {
+                long unscaled = reader.bigDecimalValue()
+                        .setScale(type.getScale(), RoundingMode.UNNECESSARY)
+                        .unscaledValue()
+                        .longValue();
+                type.writeLong(builder, unscaled);
+            };
+        }
+        else {
+            return (reader, builder) -> {
+                Int128 unscaled = Int128.valueOf(reader.bigDecimalValue()
+                        .setScale(type.getScale(), RoundingMode.UNNECESSARY)
+                        .unscaledValue());
+                type.writeObject(builder, unscaled);
+            };
+        }
+    }
+
+    private static final BlockDecoder byteDecoder = (ionReader, blockBuilder) ->
+            TinyintType.TINYINT.writeLong(blockBuilder, ionReader.longValue());
+
+    private static final BlockDecoder shortDecoder = (ionReader, blockBuilder) ->
+            SmallintType.SMALLINT.writeLong(blockBuilder, ionReader.longValue());
+
+    private static final BlockDecoder intDecoder = (ionReader, blockBuilder) ->
+            IntegerType.INTEGER.writeLong(blockBuilder, ionReader.longValue());
+
+    private static final BlockDecoder longDecoder = (ionReader, blockBuilder) ->
+            BigintType.BIGINT.writeLong(blockBuilder, ionReader.longValue());
+
+    private static final BlockDecoder realDecoder = (ionReader, blockBuilder) -> {
+        double readValue = ionReader.doubleValue();
+        if (readValue == (float) readValue) {
+            RealType.REAL.writeFloat(blockBuilder, (float) ionReader.doubleValue());
+        }
+        else {
+            // todo: some kind of "permissive truncate" flag
+            throw new IllegalArgumentException("Won't truncate double precise float to real!");
+        }
+    };
+
+    private static final BlockDecoder floatDecoder = (ionReader, blockBuilder) ->
+            DoubleType.DOUBLE.writeDouble(blockBuilder, ionReader.doubleValue());
+
+    private static final BlockDecoder stringDecoder = (ionReader, blockBuilder) ->
+            VarcharType.VARCHAR.writeSlice(blockBuilder, Slices.utf8Slice(ionReader.stringValue()));
+
+    private static final BlockDecoder boolDecoder = (ionReader, blockBuilder) ->
+            BooleanType.BOOLEAN.writeBoolean(blockBuilder, ionReader.booleanValue());
+
+    private static final BlockDecoder binaryDecoder = (ionReader, blockBuilder) ->
+            VarbinaryType.VARBINARY.writeSlice(blockBuilder, Slices.wrappedBuffer(ionReader.newBytes()));
+}

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoder.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoder.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.ion;
+
+import com.amazon.ion.IonWriter;
+import io.trino.spi.Page;
+
+import java.io.IOException;
+
+public interface IonEncoder
+{
+    /**
+     * Encodes the Page into the IonWriter provided.
+     * <p>
+     * Will flush() the writer after encoding the page.
+     * Expects that the calling code is responsible for closing
+     * the writer after all pages are written.
+     */
+    void encode(IonWriter writer, Page page)
+            throws IOException;
+}

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.ion;
+
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.Timestamp;
+import com.google.common.collect.ImmutableList;
+import io.trino.hive.formats.line.Column;
+import io.trino.spi.Page;
+import io.trino.spi.block.ArrayBlock;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RowBlock;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.Int128;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.IntFunction;
+
+public class IonEncoderFactory
+{
+    private IonEncoderFactory() {}
+
+    public static IonEncoder buildEncoder(List<Column> columns)
+    {
+        return RowEncoder.forFields(columns.stream()
+                .map(c -> new RowType.Field(Optional.of(c.name()), c.type()))
+                .toList());
+    }
+
+    private interface BlockEncoder
+    {
+        void encode(IonWriter writer, Block block, int position)
+                throws IOException;
+    }
+
+    private static BlockEncoder encoderForType(Type type)
+    {
+        return switch (type) {
+            case TinyintType _ -> byteEncoder;
+            case SmallintType _ -> shortEncoder;
+            case IntegerType _ -> intEncoder;
+            case BigintType _ -> longEncoder;
+            case BooleanType _ -> boolEncoder;
+            case VarbinaryType _ -> binaryEncoder;
+            case RealType _ -> realEncoder;
+            case DoubleType _ -> doubleEncoder;
+            case VarcharType _, CharType _ -> stringEncoder;
+            case DecimalType t -> decimalEncoder(t);
+            case TimestampType t -> timestampEncoder(t);
+            case RowType t -> RowEncoder.forFields(t.getFields()); // remember to wrap element encoder here
+            case ArrayType t -> new ArrayEncoder(wrapEncoder(encoderForType(t.getElementType()))); // remember to wrap element encoder here
+            default -> throw new IllegalArgumentException(String.format("Unsupported type: %s", type));
+        };
+    }
+
+    private static BlockEncoder wrapEncoder(BlockEncoder encoder)
+    {
+        return (writer, block, position) ->
+        {
+            if (block.isNull(position)) {
+                writer.writeNull();
+            }
+            else {
+                encoder.encode(writer, block, position);
+            }
+        };
+    }
+
+    private record RowEncoder(List<String> fieldNames, List<BlockEncoder> fieldEncoders)
+            implements BlockEncoder, IonEncoder
+    {
+        private static RowEncoder forFields(List<RowType.Field> fields)
+        {
+            ImmutableList.Builder<String> fieldNamesBuilder = ImmutableList.builder();
+            ImmutableList.Builder<BlockEncoder> fieldEncodersBuilder = ImmutableList.builder();
+
+            for (RowType.Field field : fields) {
+                fieldNamesBuilder.add(field.getName().get());
+                fieldEncodersBuilder.add(wrapEncoder(encoderForType(field.getType())));
+            }
+
+            return new RowEncoder(fieldNamesBuilder.build(), fieldEncodersBuilder.build());
+        }
+
+        @Override
+        public void encode(IonWriter writer, Block block, int position)
+                throws IOException
+        {
+            encodeStruct(writer, ((RowBlock) block)::getFieldBlock, position);
+        }
+
+        @Override
+        public void encode(IonWriter writer, Page page)
+                throws IOException
+        {
+            for (int i = 0; i < page.getPositionCount(); i++) {
+                encodeStruct(writer, page::getBlock, i);
+            }
+            // todo: it's probably preferable to decouple ion writer flushes
+            //       from page sizes, but it's convenient for now
+            writer.flush();
+        }
+
+        private void encodeStruct(IonWriter writer, IntFunction<Block> blockSelector, int position)
+                throws IOException
+        {
+            writer.stepIn(IonType.STRUCT);
+            for (int i = 0; i < fieldEncoders.size(); i++) {
+                // todo: it may be preferable to elide struct fields when null
+                //       consider what the Ion Hive Serde does
+
+                writer.setFieldName(fieldNames.get(i));
+                fieldEncoders.get(i)
+                        .encode(writer, blockSelector.apply(i), position);
+            }
+            writer.stepOut();
+        }
+    }
+
+    private record ArrayEncoder(BlockEncoder elementEncoder)
+            implements BlockEncoder
+    {
+        @Override
+        public void encode(IonWriter writer, Block block, int position)
+                throws IOException
+        {
+            writer.stepIn(IonType.LIST);
+            Block elementBlock = ((ArrayBlock) block).getArray(position);
+            for (int i = 0; i < elementBlock.getPositionCount(); i++) {
+                elementEncoder.encode(writer, elementBlock, i);
+            }
+            writer.stepOut();
+        }
+    }
+
+    private static BlockEncoder timestampEncoder(TimestampType type)
+    {
+        if (type.isShort()) {
+            return (writer, block, position) -> {
+                long epochMicros = type.getLong(block, position);
+                BigDecimal decimalMillis = BigDecimal.valueOf(epochMicros)
+                        .movePointLeft(3)
+                        .setScale(type.getPrecision() - 3, RoundingMode.UNNECESSARY);
+
+                writer.writeTimestamp(Timestamp.forMillis(decimalMillis, 0));
+            };
+        }
+        else {
+            return (writer, block, position) -> {
+                LongTimestamp longTimestamp = (LongTimestamp) type.getObject(block, position);
+                BigDecimal picosOfMicros = BigDecimal.valueOf(longTimestamp.getPicosOfMicro())
+                        .movePointLeft(9);
+                BigDecimal decimalMillis = BigDecimal.valueOf(longTimestamp.getEpochMicros())
+                        .movePointLeft(3)
+                        .add(picosOfMicros)
+                        .setScale(type.getPrecision() - 3, RoundingMode.UNNECESSARY);
+
+                writer.writeTimestamp(Timestamp.forMillis(decimalMillis, 0));
+            };
+        }
+    }
+
+    private static BlockEncoder decimalEncoder(DecimalType type)
+    {
+        if (type.isShort()) {
+            return (writer, block, position) -> {
+                writer.writeDecimal(BigDecimal.valueOf(type.getLong(block, position), type.getScale()));
+            };
+        }
+        else {
+            return (writer, block, position) -> {
+                writer.writeDecimal(new BigDecimal(((Int128) type.getObject(block, position)).toBigInteger(), type.getScale()));
+            };
+        }
+    }
+
+    private static final BlockEncoder byteEncoder = (writer, block, position) ->
+            writer.writeInt(TinyintType.TINYINT.getLong(block, position));
+
+    private static final BlockEncoder shortEncoder = (writer, block, position) ->
+            writer.writeInt(SmallintType.SMALLINT.getLong(block, position));
+
+    private static final BlockEncoder intEncoder = (writer, block, position) ->
+            writer.writeInt(IntegerType.INTEGER.getInt(block, position));
+
+    private static final BlockEncoder stringEncoder = (writer, block, position) ->
+            writer.writeString(VarcharType.VARCHAR.getSlice(block, position).toString(StandardCharsets.UTF_8));
+
+    private static final BlockEncoder boolEncoder = (writer, block, position) ->
+            writer.writeBool(BooleanType.BOOLEAN.getBoolean(block, position));
+
+    private static final BlockEncoder binaryEncoder = (writer, block, position) ->
+            writer.writeBlob(VarbinaryType.VARBINARY.getSlice(block, position).getBytes());
+
+    private static final BlockEncoder longEncoder = (writer, block, position) ->
+            writer.writeInt(BigintType.BIGINT.getLong(block, position));
+
+    private static final BlockEncoder realEncoder = (writer, block, position) ->
+            writer.writeFloat(RealType.REAL.getFloat(block, position));
+
+    private static final BlockEncoder doubleEncoder = (writer, block, position) ->
+            writer.writeFloat(DoubleType.DOUBLE.getDouble(block, position));
+}

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/FormatTestUtils.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/FormatTestUtils.java
@@ -483,6 +483,18 @@ public final class FormatTestUtils
         return page;
     }
 
+    public static Page toPage(List<Column> columns, List<?>... expectedValues)
+    {
+        PageBuilder pageBuilder = new PageBuilder(columns.stream().map(Column::type).collect(toImmutableList()));
+        for (List<?> expectedValue : expectedValues) {
+            pageBuilder.declarePosition();
+            for (int col = 0; col < columns.size(); col++) {
+                writeTrinoValue(columns.get(col).type(), pageBuilder.getBlockBuilder(col), expectedValue.get(col));
+            }
+        }
+        return pageBuilder.build();
+    }
+
     public static void writeTrinoValue(Type type, BlockBuilder blockBuilder, Object value)
     {
         if (value == null) {

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.ion;
+
+import com.amazon.ion.IonException;
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.Timestamp;
+import com.amazon.ion.system.IonReaderBuilder;
+import com.amazon.ion.system.IonTextWriterBuilder;
+import io.trino.hive.formats.line.Column;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.SqlDecimal;
+import io.trino.spi.type.SqlTimestamp;
+import io.trino.spi.type.SqlVarbinary;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.VarbinaryType;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static io.trino.hive.formats.FormatTestUtils.assertColumnValuesEquals;
+import static io.trino.hive.formats.FormatTestUtils.readTrinoValues;
+import static io.trino.hive.formats.FormatTestUtils.toPage;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RowType.field;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIonFormat
+{
+    @Test
+    public void testSuperBasicStruct()
+            throws IOException
+    {
+        assertValues(
+                RowType.rowType(
+                        field("foo", INTEGER),
+                        field("bar", VARCHAR)),
+                "{ bar: baz, foo: 31, ignored: true }",
+                List.of(31, "baz"));
+    }
+
+    @Test
+    public void testStructWithNullAndMissingValues()
+            throws IOException
+    {
+        final List<Object> listWithNulls = new ArrayList<>();
+        listWithNulls.add(null);
+        listWithNulls.add(null);
+
+        assertValues(
+                RowType.rowType(
+                        field("foo", INTEGER),
+                        field("bar", VARCHAR)),
+                "{ bar: null.symbol }",
+                listWithNulls);
+    }
+
+    @Test
+    public void testStructWithDuplicateKeys()
+            throws IOException
+    {
+        // this test is not making a value judgement; capturing the last
+        // is not necessarily the "right" behavior. the test just
+        // documents what the behavior is, which is based on the behavior
+        // of the hive serde, and is consistent with the trino json parser.
+        assertValues(
+                RowType.rowType(field("foo", INTEGER)),
+                "{ foo: 17, foo: 31, foo: 53 } { foo: 67 }",
+                List.of(53), List.of(67));
+    }
+
+    // todo: test for mistyped null and non-null values
+
+    @Test
+    public void testNestedList()
+            throws IOException
+    {
+        assertValues(
+                RowType.rowType(
+                        field("primes", new ArrayType(INTEGER))),
+                "{ primes: [ 17, 31, 51 ] }",
+                List.of(List.of(17, 31, 51)));
+    }
+
+    @Test
+    public void testNestedStruct()
+            throws IOException
+    {
+        assertValues(
+                RowType.rowType(
+                        field("name", RowType.rowType(
+                                field("first", VARCHAR),
+                                field("last", VARCHAR)))),
+                "{ name: { first: Woody, last: Guthrie } }",
+                List.of(List.of("Woody", "Guthrie")));
+    }
+
+    @Test
+    public void testStructInList()
+            throws IOException
+    {
+        assertValues(
+                RowType.rowType(
+                        field("elements", new ArrayType(
+                                RowType.rowType(
+                                        field("foo", INTEGER))))),
+                "{ elements: [ { foo: 13 }, { foo: 17 } ] }",
+                // yes, there are three layers of list here:
+                // top-level struct (row), list of elements (array), then inner struct (row)
+                List.of(
+                        List.of(List.of(13), List.of(17))));
+    }
+
+    @Test
+    public void testPicoPreciseTimestamp()
+            throws IOException
+    {
+        Timestamp ionTimestamp = Timestamp.forSecond(2067, 8, 9, 11, 22, new BigDecimal("33.445566"), 0);
+        long epochMicros = ionTimestamp.getDecimalMillis().movePointRight(3).longValue();
+        assertValues(
+                RowType.rowType(field("my_ts", TimestampType.TIMESTAMP_PICOS)),
+                "{ my_ts: 2067-08-09T11:22:33.445566778899Z }",
+                List.of(SqlTimestamp.newInstance(12, epochMicros, 778899)));
+    }
+
+    @Test
+    public void testOverPreciseTimestamps()
+            throws IonException
+    {
+        // todo: implement
+    }
+
+    @Test
+    public void testDecimalPrecisionAndScale()
+            throws IOException
+    {
+        assertValues(
+                RowType.rowType(
+                        field("amount", DecimalType.createDecimalType(10, 2)),
+                        field("big_amount", DecimalType.createDecimalType(25, 5))),
+                "{ amount: 1234.00, big_amount: 1234.00000 }"
+                        + "{ amount: 1234d0, big_amount: 1234d0 }"
+                        + "{ amount: 12d2, big_amount: 12d2 }"
+                        + "{ amount: 1234.000, big_amount: 1234.000000 }",
+                List.of(new SqlDecimal(BigInteger.valueOf(123400), 10, 2), new SqlDecimal(BigInteger.valueOf(123400000), 25, 5)),
+                List.of(new SqlDecimal(BigInteger.valueOf(123400), 10, 2), new SqlDecimal(BigInteger.valueOf(123400000), 25, 5)),
+                List.of(new SqlDecimal(BigInteger.valueOf(120000), 10, 2), new SqlDecimal(BigInteger.valueOf(120000000), 25, 5)),
+                List.of(new SqlDecimal(BigInteger.valueOf(123400), 10, 2), new SqlDecimal(BigInteger.valueOf(123400000), 25, 5)));
+    }
+
+    @Test
+    public void testOversizeOrOverpreciseDecimals()
+    {
+        // todo: implement
+    }
+
+    @Test
+    public void testEncode()
+            throws IOException
+    {
+        List<Column> columns = List.of(
+                new Column("magic_num", INTEGER, 0),
+                new Column("some_text", VARCHAR, 1),
+                new Column("is_summer", BooleanType.BOOLEAN, 2),
+                new Column("byte_clob", VarbinaryType.VARBINARY, 3),
+                new Column("sequencer", new ArrayType(INTEGER), 4),
+                new Column("struction", RowType.rowType(
+                        field("foo", INTEGER),
+                        field("bar", VARCHAR)), 5));
+
+        List<?> row1 = List.of(17, "hello", true, new SqlVarbinary(new byte[] {(byte) 0xff}), List.of(1, 2, 3), List.of(51, "baz"));
+        List<?> row2 = List.of(31, "goodbye", false, new SqlVarbinary(new byte[] {(byte) 0x01, (byte) 0xaa}), List.of(7, 8, 9), List.of(67, "qux"));
+
+        Page page = toPage(columns, row1, row2);
+
+        writeAndPrint(columns, page);
+    }
+
+    private void assertValues(RowType rowType, String ionText, List<Object>... expected)
+            throws IOException
+    {
+        final List<RowType.Field> fields = rowType.getFields();
+        final List<Column> columns = IntStream.range(0, fields.size())
+                .boxed()
+                .map(i -> {
+                    final RowType.Field field = fields.get(i);
+                    return new Column(field.getName().get(), field.getType(), i);
+                })
+                .toList();
+        final IonDecoder decoder = IonDecoderFactory.buildDecoder(columns);
+        final PageBuilder pageBuilder = new PageBuilder(expected.length, rowType.getFields().stream().map(RowType.Field::getType).toList());
+
+        try (IonReader ionReader = IonReaderBuilder.standard().build(ionText)) {
+            for (int i = 0; i < expected.length; i++) {
+                assertThat(ionReader.next()).isNotNull();
+                pageBuilder.declarePosition();
+                decoder.decode(ionReader, pageBuilder);
+            }
+            assertThat(ionReader.next()).isNull();
+        }
+
+        for (int i = 0; i < expected.length; i++) {
+            final List<Object> actual = readTrinoValues(columns, pageBuilder.build(), i);
+            assertColumnValuesEquals(columns, actual, expected[i]);
+        }
+    }
+
+    // todo: this needs to assert, not print to stderr!
+    private void writeAndPrint(List<Column> columns, Page page)
+            throws IOException
+    {
+        final IonEncoder encoder = IonEncoderFactory.buildEncoder(columns);
+        final IonWriter ionWriter = IonTextWriterBuilder.standard()
+                .build((OutputStream) System.err);
+        encoder.encode(ionWriter, page);
+        ionWriter.close();
+    }
+}

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -14,6 +14,13 @@
     <description>Trino - Hive connector</description>
 
     <dependencies>
+
+        <dependency>
+            <groupId>com.amazon.ion</groupId>
+            <artifactId>ion-java</artifactId>
+            <version>1.11.9</version>
+        </dependency>
+
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -399,6 +399,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.amazon.ion</groupId>
+            <artifactId>ion-hive3-serde</artifactId>
+            <version>1.2.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>http-server</artifactId>
             <scope>test</scope>

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -27,6 +27,8 @@ import io.trino.plugin.hive.avro.AvroPageSourceFactory;
 import io.trino.plugin.hive.fs.CachingDirectoryLister;
 import io.trino.plugin.hive.fs.DirectoryLister;
 import io.trino.plugin.hive.fs.TransactionScopeCachingDirectoryListerFactory;
+import io.trino.plugin.hive.ion.IonFileWriterFactory;
+import io.trino.plugin.hive.ion.IonPageSourceFactory;
 import io.trino.plugin.hive.line.CsvFileWriterFactory;
 import io.trino.plugin.hive.line.CsvPageSourceFactory;
 import io.trino.plugin.hive.line.JsonFileWriterFactory;
@@ -130,6 +132,7 @@ public class HiveModule
         pageSourceFactoryBinder.addBinding().to(ParquetPageSourceFactory.class).in(Scopes.SINGLETON);
         pageSourceFactoryBinder.addBinding().to(RcFilePageSourceFactory.class).in(Scopes.SINGLETON);
         pageSourceFactoryBinder.addBinding().to(AvroPageSourceFactory.class).in(Scopes.SINGLETON);
+        pageSourceFactoryBinder.addBinding().to(IonPageSourceFactory.class).in(Scopes.SINGLETON);
 
         Multibinder<HiveFileWriterFactory> fileWriterFactoryBinder = newSetBinder(binder, HiveFileWriterFactory.class);
         binder.bind(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
@@ -145,6 +148,7 @@ public class HiveModule
         fileWriterFactoryBinder.addBinding().to(OrcFileWriterFactory.class).in(Scopes.SINGLETON);
         fileWriterFactoryBinder.addBinding().to(RcFileFileWriterFactory.class).in(Scopes.SINGLETON);
         fileWriterFactoryBinder.addBinding().to(AvroFileWriterFactory.class).in(Scopes.SINGLETON);
+        fileWriterFactoryBinder.addBinding().to(IonFileWriterFactory.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(ParquetReaderConfig.class);
         configBinder(binder).bindConfig(ParquetWriterConfig.class);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveStorageFormat.java
@@ -35,6 +35,9 @@ import static io.trino.hive.formats.HiveClassNames.AVRO_SERDE_CLASS;
 import static io.trino.hive.formats.HiveClassNames.COLUMNAR_SERDE_CLASS;
 import static io.trino.hive.formats.HiveClassNames.HIVE_IGNORE_KEY_OUTPUT_FORMAT_CLASS;
 import static io.trino.hive.formats.HiveClassNames.HIVE_SEQUENCEFILE_OUTPUT_FORMAT_CLASS;
+import static io.trino.hive.formats.HiveClassNames.ION_INPUT_FORMAT;
+import static io.trino.hive.formats.HiveClassNames.ION_OUTPUT_FORMAT;
+import static io.trino.hive.formats.HiveClassNames.ION_SERDE_CLASS;
 import static io.trino.hive.formats.HiveClassNames.JSON_SERDE_CLASS;
 import static io.trino.hive.formats.HiveClassNames.LAZY_BINARY_COLUMNAR_SERDE_CLASS;
 import static io.trino.hive.formats.HiveClassNames.LAZY_SIMPLE_SERDE_CLASS;
@@ -101,7 +104,11 @@ public enum HiveStorageFormat
     REGEX(
             REGEX_SERDE_CLASS,
             TEXT_INPUT_FORMAT_CLASS,
-            HIVE_IGNORE_KEY_OUTPUT_FORMAT_CLASS);
+            HIVE_IGNORE_KEY_OUTPUT_FORMAT_CLASS),
+    ION(
+            ION_SERDE_CLASS,
+            ION_INPUT_FORMAT,
+            ION_OUTPUT_FORMAT);
 
     private final String serde;
     private final String inputFormat;
@@ -135,6 +142,7 @@ public enum HiveStorageFormat
         return switch (this) {
             case ORC, PARQUET, AVRO, RCBINARY, RCTEXT, SEQUENCEFILE -> true;
             case JSON, OPENX_JSON, TEXTFILE, CSV, REGEX -> CompressionKind.forFile(path).isEmpty();
+            case ION -> false;
         };
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
@@ -71,6 +71,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Maps.immutableEntry;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static io.trino.hive.formats.HiveClassNames.HIVE_IGNORE_KEY_OUTPUT_FORMAT_CLASS;
+import static io.trino.hive.formats.HiveClassNames.ION_OUTPUT_FORMAT;
 import static io.trino.metastore.AcidOperation.CREATE_TABLE;
 import static io.trino.plugin.hive.HiveCompressionCodecs.selectCompressionCodec;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
@@ -733,11 +734,13 @@ public class HiveWriterFactory
 
     public static String getFileExtension(HiveCompressionCodec compression, StorageFormat format)
     {
-        // text format files must have the correct extension when compressed
-        return compression.getHiveCompressionKind()
-                .filter(_ -> format.getOutputFormat().equals(HIVE_IGNORE_KEY_OUTPUT_FORMAT_CLASS))
-                .map(CompressionKind::getFileExtension)
-                .orElse("");
+        // text format files and ion format files must have the correct extension when compressed
+        return switch (format.getOutputFormat()) {
+            case ION_OUTPUT_FORMAT, HIVE_IGNORE_KEY_OUTPUT_FORMAT_CLASS -> compression.getHiveCompressionKind()
+                    .map(CompressionKind::getFileExtension)
+                    .orElse("");
+            default -> "";
+        };
     }
 
     @VisibleForTesting

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonFileWriter.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.ion;
+
+import com.amazon.ion.IonWriter;
+import com.amazon.ion.system.IonTextWriterBuilder;
+import com.google.common.io.CountingOutputStream;
+import io.trino.hive.formats.compression.CompressionKind;
+import io.trino.hive.formats.ion.IonEncoder;
+import io.trino.hive.formats.ion.IonEncoderFactory;
+import io.trino.hive.formats.line.Column;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.plugin.hive.FileWriter;
+import io.trino.spi.Page;
+import io.trino.spi.TrinoException;
+import io.trino.spi.type.TypeManager;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.LongSupplier;
+
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
+
+public class IonFileWriter
+        implements FileWriter
+{
+    private final AggregatedMemoryContext outputStreamMemoryContext;
+    private final Closeable rollbackAction;
+    private final IonEncoder pageEncoder;
+    private final IonWriter writer;
+    private final OutputStream outputStream;
+    private final LongSupplier bytesWritten;
+
+    public IonFileWriter(
+            OutputStream outputStream,
+            AggregatedMemoryContext outputStreamMemoryContext,
+            Closeable rollbackAction,
+            TypeManager typeManager,
+            Optional<CompressionKind> compressionKind,
+            List<Column> columns)
+            throws IOException
+    {
+        this.outputStreamMemoryContext = outputStreamMemoryContext;
+        this.rollbackAction = rollbackAction;
+        this.pageEncoder = IonEncoderFactory.buildEncoder(columns);
+        CountingOutputStream countingOutputStream = new CountingOutputStream(outputStream);
+        this.bytesWritten = countingOutputStream::getCount;
+        if (compressionKind.isPresent()) {
+            this.outputStream = compressionKind.get().createCodec()
+                    .createStreamCompressor(countingOutputStream);
+        }
+        else {
+            this.outputStream = countingOutputStream;
+        }
+
+        this.writer = IonTextWriterBuilder
+                .minimal()
+                .build(this.outputStream);
+    }
+
+    @Override
+    public long getWrittenBytes()
+    {
+        return bytesWritten.getAsLong();
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return outputStreamMemoryContext.getBytes();
+    }
+
+    @Override
+    public Closeable commit()
+    {
+        try {
+            writer.close();
+        }
+        catch (Exception e) {
+            try {
+                rollbackAction.close();
+            }
+            catch (Exception _) {
+                // ignore
+            }
+            throw new TrinoException(HIVE_WRITER_CLOSE_ERROR, "Error committing write to Hive", e);
+        }
+        return rollbackAction;
+    }
+
+    @Override
+    public void rollback()
+    {
+        try (rollbackAction) {
+            writer.close();
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public long getValidationCpuNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public void appendRows(Page page)
+    {
+        try {
+            pageEncoder.encode(writer, page);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonFileWriterFactory.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.ion;
+
+import com.google.inject.Inject;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.TrinoOutputFile;
+import io.trino.hive.formats.line.Column;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.metastore.StorageFormat;
+import io.trino.plugin.hive.FileWriter;
+import io.trino.plugin.hive.HiveCompressionCodec;
+import io.trino.plugin.hive.HiveFileWriterFactory;
+import io.trino.plugin.hive.WriterKind;
+import io.trino.plugin.hive.acid.AcidTransaction;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.stream.IntStream;
+
+import static io.trino.hive.formats.HiveClassNames.ION_OUTPUT_FORMAT;
+import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
+import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
+import static io.trino.plugin.hive.util.HiveTypeUtil.getType;
+import static io.trino.plugin.hive.util.HiveUtil.getColumnNames;
+import static io.trino.plugin.hive.util.HiveUtil.getColumnTypes;
+
+public class IonFileWriterFactory
+        implements HiveFileWriterFactory
+{
+    private final TrinoFileSystemFactory fileSystemFactory;
+    private final TypeManager typeManager;
+
+    @Inject
+    public IonFileWriterFactory(
+            TrinoFileSystemFactory fileSystemFactory,
+            TypeManager typeManager)
+    {
+        this.fileSystemFactory = fileSystemFactory;
+        this.typeManager = typeManager;
+    }
+
+    @Override
+    public Optional<FileWriter> createFileWriter(
+            Location location,
+            List<String> inputColumnNames,
+            StorageFormat storageFormat,
+            HiveCompressionCodec compressionCodec,
+            Map<String, String> schema,
+            ConnectorSession session,
+            OptionalInt bucketNumber,
+            AcidTransaction transaction,
+            boolean useAcidSchema,
+            WriterKind writerKind)
+    {
+        if (!ION_OUTPUT_FORMAT.equals(storageFormat.getOutputFormat())) {
+            return Optional.empty();
+        }
+        try {
+            TrinoFileSystem fileSystem = fileSystemFactory.create(session);
+            TrinoOutputFile outputFile = fileSystem.newOutputFile(location);
+            AggregatedMemoryContext outputStreamMemoryContext = newSimpleAggregatedMemoryContext();
+
+            Closeable rollbackAction = () -> fileSystem.deleteFile(location);
+
+            // we take the column names from the schema, not what was input
+            // this is what the LineWriterFactory does, I don't understand why
+            List<String> fileColumnNames = getColumnNames(schema);
+            List<Type> fileColumnTypes = getColumnTypes(schema).stream()
+                    .map(hiveType -> getType(hiveType, typeManager, getTimestampPrecision(session)))
+                    .toList();
+
+            List<Column> columns = IntStream.range(0, fileColumnNames.size())
+                    .mapToObj(ordinal -> new Column(fileColumnNames.get(ordinal), fileColumnTypes.get(ordinal), ordinal))
+                    .toList();
+
+            return Optional.of(new IonFileWriter(
+                    outputFile.create(outputStreamMemoryContext),
+                    outputStreamMemoryContext,
+                    rollbackAction,
+                    typeManager,
+                    compressionCodec.getHiveCompressionKind(),
+                    columns));
+        }
+        catch (Exception e) {
+            throw new TrinoException(HIVE_WRITER_OPEN_ERROR, "Error creating Ion Output", e);
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSource.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.ion;
+
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonType;
+import io.trino.hive.formats.ion.IonDecoder;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.connector.ConnectorPageSource;
+
+import java.io.IOException;
+import java.util.OptionalLong;
+import java.util.function.LongSupplier;
+
+public class IonPageSource
+        implements ConnectorPageSource
+{
+    private final IonReader ionReader;
+    private final PageBuilder pageBuilder;
+    private final IonDecoder decoder;
+    private final LongSupplier counter;
+    private int completedPositions;
+    private boolean finished;
+
+    public IonPageSource(IonReader ionReader, LongSupplier counter, IonDecoder decoder, PageBuilder pageBuilder)
+    {
+        this.ionReader = ionReader;
+        this.decoder = decoder;
+        this.pageBuilder = pageBuilder;
+        this.counter = counter;
+        this.completedPositions = 0;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return counter.getAsLong();
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return OptionalLong.of(completedPositions);
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return finished;
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        while (!pageBuilder.isFull()) {
+            if (!readNextValue()) {
+                finished = true;
+                break;
+            }
+        }
+
+        Page page = pageBuilder.build();
+        completedPositions += page.getPositionCount();
+        pageBuilder.reset();
+        return page;
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return 4096;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        ionReader.close();
+    }
+
+    private boolean readNextValue()
+    {
+        final IonType type = ionReader.next();
+        if (type == null) {
+            return false;
+        }
+
+        pageBuilder.declarePosition();
+        decoder.decode(ionReader, pageBuilder);
+        return true;
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSourceFactory.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.ion;
+
+import com.amazon.ion.IonReader;
+import com.amazon.ion.system.IonReaderBuilder;
+import com.google.common.io.CountingInputStream;
+import com.google.inject.Inject;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.TrinoInputFile;
+import io.trino.hive.formats.compression.Codec;
+import io.trino.hive.formats.compression.CompressionKind;
+import io.trino.hive.formats.ion.IonDecoder;
+import io.trino.hive.formats.ion.IonDecoderFactory;
+import io.trino.hive.formats.line.Column;
+import io.trino.plugin.hive.AcidInfo;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.plugin.hive.HivePageSourceFactory;
+import io.trino.plugin.hive.ReaderColumns;
+import io.trino.plugin.hive.ReaderPageSource;
+import io.trino.plugin.hive.Schema;
+import io.trino.plugin.hive.acid.AcidTransaction;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.EmptyPageSource;
+import io.trino.spi.predicate.TupleDomain;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.hive.formats.HiveClassNames.ION_SERDE_CLASS;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
+import static io.trino.plugin.hive.HivePageSourceProvider.projectBaseColumns;
+import static io.trino.plugin.hive.ReaderPageSource.noProjectionAdaptation;
+import static io.trino.plugin.hive.util.HiveUtil.splitError;
+
+public class IonPageSourceFactory
+        implements HivePageSourceFactory
+{
+    private final TrinoFileSystemFactory trinoFileSystemFactory;
+
+    @Inject
+    public IonPageSourceFactory(TrinoFileSystemFactory trinoFileSystemFactory)
+    {
+        this.trinoFileSystemFactory = trinoFileSystemFactory;
+    }
+
+    @Override
+    public Optional<ReaderPageSource> createPageSource(
+            ConnectorSession session,
+            Location path,
+            long start,
+            long length,
+            long estimatedFileSize,
+            long lastModifiedTime,
+            Schema schema,
+            List<HiveColumnHandle> columns,
+            TupleDomain<HiveColumnHandle> effectivePredicate,
+            Optional<AcidInfo> acidInfo,
+            OptionalInt bucketNumber,
+            boolean originalFile,
+            AcidTransaction transaction)
+    {
+        if (!ION_SERDE_CLASS.equals(schema.serializationLibraryName())) {
+            return Optional.empty();
+        }
+        checkArgument(acidInfo.isEmpty(), "Acid is not supported for Ion files");
+
+        // Skip empty inputs
+        if (length == 0) {
+            return Optional.of(noProjectionAdaptation(new EmptyPageSource()));
+        }
+
+        if (start != 0) {
+            throw new TrinoException(HIVE_CANNOT_OPEN_SPLIT, "Split start must be 0 for Ion files");
+        }
+
+        List<HiveColumnHandle> projectedReaderColumns = columns;
+        Optional<ReaderColumns> readerProjections = projectBaseColumns(columns);
+
+        if (readerProjections.isPresent()) {
+            projectedReaderColumns = readerProjections.get().get().stream()
+                    .map(HiveColumnHandle.class::cast)
+                    .collect(toImmutableList());
+        }
+
+        TrinoFileSystem trinoFileSystem = trinoFileSystemFactory.create(session);
+        TrinoInputFile inputFile = trinoFileSystem.newInputFile(path, estimatedFileSize);
+
+        // todo: optimization for small files that should just be read into memory
+        try {
+            Optional<Codec> codec = CompressionKind.forFile(inputFile.location().fileName())
+                    .map(CompressionKind::createCodec);
+            CountingInputStream countingInputStream = new CountingInputStream(inputFile.newStream());
+            InputStream inputStream;
+            if (codec.isPresent()) {
+                inputStream = codec.get().createStreamDecompressor(countingInputStream);
+            }
+            else {
+                inputStream = countingInputStream;
+            }
+
+            IonReader ionReader = IonReaderBuilder
+                    .standard()
+                    .build(inputStream);
+            PageBuilder pageBuilder = new PageBuilder(projectedReaderColumns.stream()
+                    .map(HiveColumnHandle::getType)
+                    .toList());
+            List<Column> decoderColumns = projectedReaderColumns.stream()
+                    .map(hc -> new Column(hc.getName(), hc.getType(), hc.getBaseHiveColumnIndex()))
+                    .toList();
+            IonDecoder decoder = IonDecoderFactory.buildDecoder(decoderColumns);
+            IonPageSource pageSource = new IonPageSource(ionReader, countingInputStream::getCount, decoder, pageBuilder);
+
+            return Optional.of(new ReaderPageSource(pageSource, readerProjections));
+        }
+        catch (IOException e) {
+            throw new TrinoException(HIVE_CANNOT_OPEN_SPLIT, splitError(e, path, start, length), e);
+        }
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseHiveConnectorTest.java
@@ -5680,6 +5680,7 @@ public abstract class BaseHiveConnectorTest
             case PARQUET -> true;
             case AVRO -> true;
             case JSON -> true;
+            case ION -> true;
             case ORC -> false;
             case RCBINARY -> false;
             case RCTEXT -> false;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveTestUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveTestUtils.java
@@ -35,6 +35,8 @@ import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesIndexPageSorter;
 import io.trino.plugin.hive.avro.AvroFileWriterFactory;
 import io.trino.plugin.hive.avro.AvroPageSourceFactory;
+import io.trino.plugin.hive.ion.IonFileWriterFactory;
+import io.trino.plugin.hive.ion.IonPageSourceFactory;
 import io.trino.plugin.hive.line.CsvFileWriterFactory;
 import io.trino.plugin.hive.line.CsvPageSourceFactory;
 import io.trino.plugin.hive.line.JsonFileWriterFactory;
@@ -56,6 +58,7 @@ import io.trino.plugin.hive.parquet.ParquetPageSourceFactory;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.plugin.hive.rcfile.RcFilePageSourceFactory;
+import io.trino.plugin.hive.util.HiveTypeTranslator;
 import io.trino.spi.PageSorter;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
@@ -188,6 +191,7 @@ public final class HiveTestUtils
                 .add(new RcFilePageSourceFactory(fileSystemFactory, hiveConfig))
                 .add(new OrcPageSourceFactory(new OrcReaderConfig(), fileSystemFactory, stats, hiveConfig))
                 .add(new ParquetPageSourceFactory(fileSystemFactory, stats, new ParquetReaderConfig(), hiveConfig))
+                .add(new IonPageSourceFactory(fileSystemFactory))
                 .build();
     }
 
@@ -210,6 +214,7 @@ public final class HiveTestUtils
                 .add(new RcFileFileWriterFactory(fileSystemFactory, TESTING_TYPE_MANAGER, nodeVersion, hiveConfig))
                 .add(new OrcFileWriterFactory(fileSystemFactory, TESTING_TYPE_MANAGER, nodeVersion, new FileFormatDataSourceStats(), new OrcWriterConfig()))
                 .add(new ParquetFileWriterFactory(fileSystemFactory, nodeVersion, TESTING_TYPE_MANAGER, hiveConfig, new FileFormatDataSourceStats()))
+                .add(new IonFileWriterFactory(fileSystemFactory, TESTING_TYPE_MANAGER))
                 .build();
     }
 
@@ -315,6 +320,62 @@ public final class HiveTestUtils
         }
 
         throw new IllegalArgumentException("Unsupported type: " + type);
+    }
+
+    public static HiveColumnHandle toHiveBaseColumnHandle(String name, Type type, int ordinal)
+    {
+        return new HiveColumnHandle(
+                name,
+                ordinal,
+                HiveTypeTranslator.toHiveType(type),
+                type,
+                Optional.empty(),
+                HiveColumnHandle.ColumnType.REGULAR,
+                Optional.empty());
+    }
+
+    public static HiveColumnHandle projectedColumn(HiveColumnHandle baseColumn, String... path)
+    {
+        if (path.length == 0) {
+            throw new IllegalArgumentException("path must have at least one element");
+        }
+
+        final Type baseType = baseColumn.getBaseType();
+        Type type = baseType;
+        ImmutableList.Builder<Integer> derefBuilder = ImmutableList.builder();
+
+        for (String fieldName : path) {
+            if (type instanceof RowType rowType) {
+                List<RowType.Field> fields = rowType.getFields();
+                type = null;
+                for (int pos = 0; pos < fields.size(); pos++) {
+                    if (fields.get(pos).getName().get().equals(fieldName)) {
+                        derefBuilder.add(pos);
+                        type = fields.get(pos).getType();
+                        break;
+                    }
+                }
+                if (type == null) {
+                    throw new IllegalArgumentException(String.format("could not find field named: %s!", fieldName));
+                }
+            }
+            else {
+                throw new IllegalArgumentException("cannot step into non-RowType!");
+            }
+        }
+
+        return new HiveColumnHandle(
+                baseColumn.getBaseColumnName(),
+                baseColumn.getBaseHiveColumnIndex(),
+                HiveTypeTranslator.toHiveType(baseType),
+                baseType,
+                Optional.of(new HiveColumnProjectionInfo(
+                        derefBuilder.build(),
+                        ImmutableList.copyOf(path),
+                        HiveTypeTranslator.toHiveType(type),
+                        type)),
+                baseColumn.getColumnType(),
+                baseColumn.getComment());
     }
 
     private static UUID uuidFromBytes(byte[] bytes)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -31,6 +31,8 @@ import io.trino.orc.OrcWriterOptions;
 import io.trino.plugin.base.type.DecodedTimestamp;
 import io.trino.plugin.hive.avro.AvroFileWriterFactory;
 import io.trino.plugin.hive.avro.AvroPageSourceFactory;
+import io.trino.plugin.hive.ion.IonFileWriterFactory;
+import io.trino.plugin.hive.ion.IonPageSourceFactory;
 import io.trino.plugin.hive.line.CsvFileWriterFactory;
 import io.trino.plugin.hive.line.CsvPageSourceFactory;
 import io.trino.plugin.hive.line.JsonFileWriterFactory;
@@ -140,6 +142,7 @@ import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMapping.buildCol
 import static io.trino.plugin.hive.HivePartitionKey.HIVE_DEFAULT_DYNAMIC_PARTITION;
 import static io.trino.plugin.hive.HiveStorageFormat.AVRO;
 import static io.trino.plugin.hive.HiveStorageFormat.CSV;
+import static io.trino.plugin.hive.HiveStorageFormat.ION;
 import static io.trino.plugin.hive.HiveStorageFormat.JSON;
 import static io.trino.plugin.hive.HiveStorageFormat.OPENX_JSON;
 import static io.trino.plugin.hive.HiveStorageFormat.ORC;
@@ -362,6 +365,23 @@ public final class TestHiveFileFormats
                 .withSkipGenericWriterTest()
                 .withFileWriterFactory(fileSystemFactory -> new OpenXJsonFileWriterFactory(fileSystemFactory, TESTING_TYPE_MANAGER))
                 .isReadableByPageSource(fileSystemFactory -> new OpenXJsonPageSourceFactory(fileSystemFactory, new HiveConfig()));
+    }
+
+    @Test(dataProvider = "validRowAndFileSizePadding")
+    public void testIon(int rowCount, long fileSizePadding)
+            throws Exception
+    {
+        List<TestColumn> testColumns = TEST_COLUMNS.stream()
+                // todo: add support for maps to trino impl
+                .filter(tc -> !(tc.type instanceof MapType))
+                .collect(toList());
+
+        assertThatFileFormat(ION)
+                .withColumns(testColumns)
+                .withRowsCount(rowCount)
+                .withFileSizePadding(fileSizePadding)
+                .withFileWriterFactory(fileSystemFactory -> new IonFileWriterFactory(fileSystemFactory, TESTING_TYPE_MANAGER))
+                .isReadableByPageSource(fileSystemFactory -> new IonPageSourceFactory(fileSystemFactory));
     }
 
     @Test(dataProvider = "validRowAndFileSizePadding")

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/ion/IonPageSourceSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/ion/IonPageSourceSmokeTest.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.ion;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.filesystem.Location;
+import io.trino.filesystem.TrinoFileSystem;
+import io.trino.filesystem.TrinoFileSystemFactory;
+import io.trino.filesystem.TrinoOutputFile;
+import io.trino.filesystem.memory.MemoryFileSystemFactory;
+import io.trino.metastore.HiveType;
+import io.trino.plugin.hive.HiveColumnHandle;
+import io.trino.plugin.hive.HiveConfig;
+import io.trino.plugin.hive.HivePageSourceProvider;
+import io.trino.plugin.hive.Schema;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.RowType;
+import io.trino.testing.MaterializedResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.stream.Collectors;
+
+import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMapping.buildColumnMappings;
+import static io.trino.plugin.hive.HiveStorageFormat.ION;
+import static io.trino.plugin.hive.HiveTestUtils.getHiveSession;
+import static io.trino.plugin.hive.HiveTestUtils.projectedColumn;
+import static io.trino.plugin.hive.HiveTestUtils.toHiveBaseColumnHandle;
+import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
+import static io.trino.plugin.hive.util.SerdeConstants.LIST_COLUMNS;
+import static io.trino.plugin.hive.util.SerdeConstants.LIST_COLUMN_TYPES;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RowType.field;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+
+/**
+ * Most basic test to reflect PageSource-fu is wired up correctly.
+ */
+public class IonPageSourceSmokeTest
+{
+    @Test
+    public void testReadTwoValues()
+            throws IOException
+    {
+        List<HiveColumnHandle> tableColumns = List.of(
+                toHiveBaseColumnHandle("foo", INTEGER, 0),
+                toHiveBaseColumnHandle("bar", VARCHAR, 1));
+
+        assertRowCount(
+                tableColumns,
+                tableColumns,
+                "{ foo: 31, bar: baz } { foo: 31, bar: \"baz\" }",
+                2);
+    }
+
+    @Test
+    public void testReadArray()
+            throws IOException
+    {
+        List<HiveColumnHandle> tablesColumns = List.of(
+                toHiveBaseColumnHandle("my_seq", new ArrayType(BOOLEAN), 0));
+
+        assertRowCount(
+                tablesColumns,
+                tablesColumns,
+                "{ my_seq: ( true false ) } { my_seq: [false, false, true] }",
+                2);
+    }
+
+    @Test
+    public void testProjectedColumn()
+            throws IOException
+    {
+        final RowType spamType = RowType.rowType(field("nested_to_prune", INTEGER), field("eggs", INTEGER));
+        List<HiveColumnHandle> tableColumns = List.of(
+                toHiveBaseColumnHandle("spam", spamType, 0),
+                toHiveBaseColumnHandle("ham", BOOLEAN, 1));
+        List<HiveColumnHandle> projectedColumns = List.of(
+                projectedColumn(tableColumns.get(0), "eggs"));
+
+        assertRowCount(
+                tableColumns,
+                projectedColumns,
+                // the data below reflects that "ham" is not decoded, that column is pruned
+                // "nested_to_prune" is decoded, however, because nested fields are not pruned, yet.
+                // so this test will fail if you change that to something other than an int
+                "{ spam: { nested_to_prune: 31, eggs: 12 }, ham: exploding }",
+                1);
+    }
+
+    private void assertRowCount(List<HiveColumnHandle> tableColumns, List<HiveColumnHandle> projectedColumns, String ionText, int rowCount)
+            throws IOException
+    {
+        TrinoFileSystemFactory fileSystemFactory = new MemoryFileSystemFactory();
+        Location location = Location.of("memory:///test.ion");
+
+        final ConnectorSession session = getHiveSession(new HiveConfig());
+
+        int written = writeIonTextFile(ionText, location, fileSystemFactory.create(session));
+        System.err.println("Wrote " + written + " bytes");
+
+        try (ConnectorPageSource pageSource = createPageSource(fileSystemFactory, location, tableColumns, projectedColumns, session)) {
+            final MaterializedResult result = MaterializedResult.materializeSourceDataStream(session, pageSource, projectedColumns.stream().map(HiveColumnHandle::getType).toList());
+            Assertions.assertEquals(rowCount, result.getRowCount());
+        }
+    }
+
+    private int writeIonTextFile(String ionText, Location location, TrinoFileSystem fileSystem)
+            throws IOException
+    {
+        final TrinoOutputFile outputFile = fileSystem.newOutputFile(location);
+        int written = 0;
+        try (OutputStream outputStream = outputFile.create()) {
+            byte[] bytes = ionText.getBytes(StandardCharsets.UTF_8);
+            outputStream.write(bytes);
+            outputStream.flush();
+            written = bytes.length;
+        }
+        return written;
+    }
+
+    /**
+     * todo: this is very similar to what's in TestOrcPredicates, factor out.
+     */
+    private static ConnectorPageSource createPageSource(
+            TrinoFileSystemFactory fileSystemFactory,
+            Location location,
+            List<HiveColumnHandle> tableColumns,
+            List<HiveColumnHandle> projectedColumns,
+            ConnectorSession session)
+            throws IOException
+    {
+        IonPageSourceFactory factory = new IonPageSourceFactory(fileSystemFactory);
+
+        long length = fileSystemFactory.create(session).newInputFile(location).length();
+        System.err.println("Found " + length + " bytes to read");
+
+        long nowMillis = Instant.now().toEpochMilli();
+
+        List<HivePageSourceProvider.ColumnMapping> columnMappings = buildColumnMappings(
+                "",
+                ImmutableList.of(),
+                projectedColumns,
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                location.toString(),
+                OptionalInt.empty(),
+                length,
+                nowMillis);
+
+        final Map<String, String> tableProperties = ImmutableMap.<String, String>builder()
+                .put(LIST_COLUMNS, tableColumns.stream().map(HiveColumnHandle::getName).collect(Collectors.joining(",")))
+                .put(LIST_COLUMN_TYPES, tableColumns.stream().map(HiveColumnHandle::getHiveType).map(HiveType::toString).collect(Collectors.joining(",")))
+                .buildOrThrow();
+
+        return HivePageSourceProvider.createHivePageSource(
+                        ImmutableSet.of(factory),
+                        session,
+                        location,
+                        OptionalInt.empty(),
+                        0,
+                        length,
+                        length,
+                        nowMillis,
+                        new Schema(ION.getSerde(), false, tableProperties),
+                        TupleDomain.all(),
+                        TESTING_TYPE_MANAGER,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        false,
+                        NO_ACID_TRANSACTION,
+                        columnMappings)
+                .orElseThrow();
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/ion/IonPageSourceSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/ion/IonPageSourceSmokeTest.java
@@ -122,8 +122,7 @@ public class IonPageSourceSmokeTest
 
         final ConnectorSession session = getHiveSession(new HiveConfig());
 
-        int written = writeIonTextFile(ionText, location, fileSystemFactory.create(session));
-        System.err.println("Wrote " + written + " bytes");
+        writeIonTextFile(ionText, location, fileSystemFactory.create(session));
 
         try (ConnectorPageSource pageSource = createPageSource(fileSystemFactory, location, tableColumns, projectedColumns, session)) {
             final MaterializedResult result = MaterializedResult.materializeSourceDataStream(session, pageSource, projectedColumns.stream().map(HiveColumnHandle::getType).toList());
@@ -159,8 +158,6 @@ public class IonPageSourceSmokeTest
         IonPageSourceFactory factory = new IonPageSourceFactory(fileSystemFactory);
 
         long length = fileSystemFactory.create(session).newInputFile(location).length();
-        System.err.println("Found " + length + " bytes to read");
-
         long nowMillis = Instant.now().toEpochMilli();
 
         List<HivePageSourceProvider.ColumnMapping> columnMappings = buildColumnMappings(

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -307,6 +307,8 @@ public class TestHiveStorageFormats
                 .filter(format -> !"JSON".equals(format))
                 // OPENX is not supported in Hive by default
                 .filter(format -> !"OPENX_JSON".equals(format))
+                // Ion is not supported in Hive by default
+                .filter(format -> !"ION".equals(format))
                 .collect(toImmutableSet());
 
         assertThat(ImmutableSet.copyOf(storageFormats()))


### PR DESCRIPTION
This is the initial implementation of a Native Trino Ion Hive format.

It does not handle the full range of Trino or Ion values, nor the set of coercions that we will likely need to implement. But I think it's a pretty good start.

I chose to avoid building off of the "Line" abstractions. While that could be done, and more closely mimics how the Ion Hive SerDe works, doing so is suboptimal, and for reading is actually more complicated. This is because while Ion is unschema'ed, each value stream has an evolving "encoding context." In Ion 1.0 that is the "Symbol Table" which is a form of dictionary encoding for the field names and other common text values.

The other high-level choice was _not_ to use the
ion-java-path-extraction library that is used in the Hive SerDe. The main value in that was to allow users to do path navigation in the SerDe config. But using it to go into the Block abstractions without a middle layer (as it uses in Hive SerDe) is complex, and I'm concerned that some data quality issues are effectively silenced. Given Trino's current capability set with nested and complex structures I doubt the value proposition. In fact, using SerDe config for what can be expressed in SQL is actually an anti-pattern.

I'm not crazy on the seperation of concerns for the IonPageSource vs Decoder: it feels like there's a bit of coupling right now. So that may need revisiting.

There's also some smaller random stuff that is documented with TODOs. I debated addressing them, but thought it was
better to share and get some feedback first.