### PR TITLE
Adds support for case insensitivity in field names

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
@@ -72,7 +72,7 @@ public class IonDecoderFactory
     {
         return RowDecoder.forFields(
                 columns.stream()
-                        .map(c -> new RowType.Field(Optional.of(c.name().toLowerCase(Locale.ROOT)), c.type()))
+                        .map(c -> new RowType.Field(Optional.of(c.name()), c.type()))
                         .toList());
     }
 

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
@@ -49,6 +49,7 @@ import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -71,7 +72,7 @@ public class IonDecoderFactory
     {
         return RowDecoder.forFields(
                 columns.stream()
-                        .map(c -> new RowType.Field(Optional.of(c.name()), c.type()))
+                        .map(c -> new RowType.Field(Optional.of(c.name().toLowerCase(Locale.ROOT)), c.type()))
                         .toList());
     }
 
@@ -145,7 +146,7 @@ public class IonDecoderFactory
                     .forEach(position -> {
                         RowType.Field field = fields.get(position);
                         decoderBuilder.add(decoderForType(field.getType()));
-                        fieldPositionBuilder.put(field.getName().get(), position);
+                        fieldPositionBuilder.put(field.getName().get().toLowerCase(Locale.ROOT), position);
                     });
 
             return new RowDecoder(fieldPositionBuilder.buildOrThrow(), decoderBuilder.build());
@@ -181,7 +182,7 @@ public class IonDecoderFactory
 
             while (ionReader.next() != null) {
                 // todo: case insensitivity
-                final Integer fieldIndex = fieldPositions.get(ionReader.getFieldName());
+                final Integer fieldIndex = fieldPositions.get(ionReader.getFieldName().toLowerCase(Locale.ROOT));
                 if (fieldIndex == null) {
                     continue;
                 }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
@@ -49,6 +49,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.function.IntFunction;
 
@@ -59,7 +60,7 @@ public class IonEncoderFactory
     public static IonEncoder buildEncoder(List<Column> columns)
     {
         return RowEncoder.forFields(columns.stream()
-                .map(c -> new RowType.Field(Optional.of(c.name()), c.type()))
+                .map(c -> new RowType.Field(Optional.of(c.name().toLowerCase(Locale.ROOT)), c.type()))
                 .toList());
     }
 
@@ -112,7 +113,7 @@ public class IonEncoderFactory
             ImmutableList.Builder<BlockEncoder> fieldEncodersBuilder = ImmutableList.builder();
 
             for (RowType.Field field : fields) {
-                fieldNamesBuilder.add(field.getName().get());
+                fieldNamesBuilder.add(field.getName().get().toLowerCase(Locale.ROOT));
                 fieldEncodersBuilder.add(wrapEncoder(encoderForType(field.getType())));
             }
 

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
@@ -66,6 +66,32 @@ public class TestIonFormat
     }
 
     @Test
+    public void testCaseInsensitivityOfKeys()
+            throws IOException
+    {
+        assertValues(
+                RowType.rowType(
+                        field("Foo", INTEGER),
+                        field("BAR", VARCHAR)),
+                "{ Bar: baz, foo: 31 }",
+                List.of(31, "baz"));
+    }
+
+    @Test
+    public void testCaseInsensitivityOfDuplicateKeys()
+            throws IOException
+    {
+        // this test asserts that duplicate key behavior works as expected(i.e. capturing the last value),
+        // for duplicate keys with different casing.
+        assertValues(
+                RowType.rowType(
+                        field("Foo", INTEGER),
+                        field("BAR", VARCHAR)),
+                "{ bar: baz, Foo: 31, foo: 5 }",
+                List.of(5, "baz"));
+    }
+
+    @Test
     public void testStructWithNullAndMissingValues()
             throws IOException
     {


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description
This PR adds support for case insensitivity in field names for Ion parser and makes it consistent with json parser.


<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## List of changes
- [Adds support for case-insensitivity for field names](https://github.com/rmarrowstone/trino/commit/a672b42c1d52c335ca2b1bcb01beeeb905fc4c95)
   - Converts the field name into lower case for both Decoder and Encoder to ensure case-insensitivity for field names/keys
- [Adds tests for case insensitivity in field names](https://github.com/rmarrowstone/trino/commit/c2186e8e4abebd088c0dc1f0c6e117295ee56ce8)

<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->

