### PR TITLE
Adds suppprt map type with string key

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
@@ -19,11 +19,14 @@ import com.amazon.ion.IonType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slices;
+import io.trino.hive.formats.DistinctMapKeys;
 import io.trino.hive.formats.line.Column;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.ArrayBlockBuilder;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.MapBlockBuilder;
 import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.block.ValueBlock;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.BooleanType;
@@ -34,6 +37,7 @@ import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.MapType;
 import io.trino.spi.type.RealType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.SmallintType;
@@ -96,6 +100,8 @@ public class IonDecoderFactory
             case DecimalType t -> wrapDecoder(decimalDecoder(t), IonType.DECIMAL);
             case VarcharType _, CharType _ -> wrapDecoder(stringDecoder, IonType.STRING, IonType.SYMBOL);
             case VarbinaryType _ -> wrapDecoder(binaryDecoder, IonType.BLOB, IonType.CLOB);
+            case MapType mapType -> wrapDecoder(new MapDecoder(mapType, decoderForType(mapType.getValueType())),
+                    IonType.STRUCT);
             case RowType r -> wrapDecoder(RowDecoder.forFields(r.getFields()), IonType.STRUCT);
             case ArrayType a -> wrapDecoder(new ArrayDecoder(decoderForType(a.getElementType())), IonType.LIST, IonType.SEXP);
             default -> throw new IllegalArgumentException(String.format("Unsupported type: %s", type));
@@ -202,6 +208,61 @@ public class IonDecoderFactory
                 }
             }
 
+            ionReader.stepOut();
+        }
+    }
+
+    private static class MapDecoder
+            implements BlockDecoder
+    {
+        private final BlockDecoder valueDecoder;
+        private final Type keyType;
+        private final Type valueType;
+        private final DistinctMapKeys distinctMapKeys;
+        private BlockBuilder keyBlockBuilder;
+        private BlockBuilder valueBlockBuilder;
+
+        public MapDecoder(MapType mapType, BlockDecoder valueDecoder)
+        {
+            this.keyType = mapType.getKeyType();
+            this.valueType = mapType.getValueType();
+            this.valueDecoder = valueDecoder;
+            this.distinctMapKeys = new DistinctMapKeys(mapType, true);
+            this.keyBlockBuilder = mapType.getKeyType().createBlockBuilder(null, 128);
+            this.valueBlockBuilder = mapType.getValueType().createBlockBuilder(null, 128);
+        }
+
+        @Override
+        public void decode(IonReader ionReader, BlockBuilder builder)
+        {
+            ionReader.stepIn();
+            // buffer the keys and values
+            while (ionReader.next() != null) {
+                if (keyType instanceof VarcharType _ || keyType instanceof CharType _) {
+                    VarcharType.VARCHAR.writeSlice(keyBlockBuilder, Slices.utf8Slice(ionReader.getFieldName()));
+                }
+                else {
+                    throw new UnsupportedOperationException("Unsupported map key type: " + keyType);
+                }
+                valueDecoder.decode(ionReader, valueBlockBuilder);
+            }
+            ValueBlock keys = keyBlockBuilder.buildValueBlock();
+            ValueBlock values = valueBlockBuilder.buildValueBlock();
+            keyBlockBuilder = keyType.createBlockBuilder(null, keys.getPositionCount());
+            valueBlockBuilder = valueType.createBlockBuilder(null, values.getPositionCount());
+
+            // copy the distinct key entries to the output
+            boolean[] distinctKeys = distinctMapKeys.selectDistinctKeys(keys);
+
+            ((MapBlockBuilder) builder).buildEntry((keyBuilder, valueBuilder) -> {
+                for (int index = 0; index < distinctKeys.length; index++) {
+                    boolean distinctKey = distinctKeys[index];
+                    if (distinctKey) {
+                        keyBuilder.append(keys, index);
+                        valueBuilder.append(values, index);
+                    }
+                }
+            });
             ionReader.stepOut();
         }
     }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
@@ -225,6 +225,9 @@ public class IonDecoderFactory
         public MapDecoder(MapType mapType, BlockDecoder valueDecoder)
         {
             this.keyType = mapType.getKeyType();
+            if (!(keyType instanceof VarcharType _ || keyType instanceof CharType _)) {
+                throw new UnsupportedOperationException("Unsupported map key type: " + keyType);
+            }
             this.valueType = mapType.getValueType();
             this.valueDecoder = valueDecoder;
             this.distinctMapKeys = new DistinctMapKeys(mapType, true);
@@ -238,12 +241,7 @@ public class IonDecoderFactory
             ionReader.stepIn();
             // buffer the keys and values
             while (ionReader.next() != null) {
-                if (keyType instanceof VarcharType _ || keyType instanceof CharType _) {
-                    VarcharType.VARCHAR.writeSlice(keyBlockBuilder, Slices.utf8Slice(ionReader.getFieldName()));
-                }
-                else {
-                    throw new UnsupportedOperationException("Unsupported map key type: " + keyType);
-                }
+                VarcharType.VARCHAR.writeSlice(keyBlockBuilder, Slices.utf8Slice(ionReader.getFieldName()));
                 valueDecoder.decode(ionReader, valueBlockBuilder);
             }
             ValueBlock keys = keyBlockBuilder.buildValueBlock();

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
@@ -22,6 +22,7 @@ import io.trino.spi.Page;
 import io.trino.spi.block.ArrayBlock;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RowBlock;
+import io.trino.spi.block.SqlMap;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.BooleanType;
@@ -32,6 +33,7 @@ import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.Int128;
 import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.MapType;
 import io.trino.spi.type.RealType;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.SmallintType;
@@ -52,6 +54,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.function.IntFunction;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class IonEncoderFactory
 {
@@ -85,6 +89,8 @@ public class IonEncoderFactory
             case DecimalType t -> decimalEncoder(t);
             case DateType _ -> dateEncoder;
             case TimestampType t -> timestampEncoder(t);
+            case MapType t -> new MapEncoder(t, t.getKeyType(),
+                    encoderForType(t.getValueType()));
             case RowType t -> RowEncoder.forFields(t.getFields());
             case ArrayType t -> new ArrayEncoder(wrapEncoder(encoderForType(t.getElementType())));
             default -> throw new IllegalArgumentException(String.format("Unsupported type: %s", type));
@@ -148,6 +154,35 @@ public class IonEncoderFactory
                 writer.setFieldName(fieldNames.get(i));
                 fieldEncoders.get(i)
                         .encode(writer, blockSelector.apply(i), position);
+            }
+            writer.stepOut();
+        }
+    }
+
+    private record MapEncoder(MapType mapType, Type keyType,
+                        BlockEncoder encoder)
+            implements BlockEncoder
+    {
+        @Override
+        public void encode(IonWriter writer, Block block, int position)
+                throws IOException
+        {
+            SqlMap sqlMap = mapType.getObject(block, position);
+            int rawOffset = sqlMap.getRawOffset();
+            Block rawKeyBlock = sqlMap.getRawKeyBlock();
+            Block rawValueBlock = sqlMap.getRawValueBlock();
+
+            writer.stepIn(IonType.STRUCT);
+            for (int i = 0; i < sqlMap.getSize(); i++) {
+                checkArgument(!rawKeyBlock.isNull(rawOffset + i), "map key is null");
+                if (keyType instanceof VarcharType _ || keyType instanceof CharType _) {
+                    writer.setFieldName(VarcharType.VARCHAR.getSlice(rawKeyBlock, rawOffset + i).toString(StandardCharsets.UTF_8));
+                }
+                else {
+                    throw new UnsupportedOperationException("Unsupported map key type: " + keyType);
+                }
+
+                encoder.encode(writer, rawValueBlock, rawOffset + i);
             }
             writer.stepOut();
         }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
@@ -167,6 +167,17 @@ public class IonEncoderFactory
                         BlockEncoder encoder)
             implements BlockEncoder
     {
+        public MapEncoder(MapType mapType, Type keyType, BlockEncoder encoder)
+
+        {
+            this.mapType = mapType;
+            if (!(keyType instanceof VarcharType _ || keyType instanceof CharType _)) {
+                throw new UnsupportedOperationException("Unsupported map key type: " + keyType);
+            }
+            this.keyType = keyType;
+            this.encoder = encoder;
+        }
+
         @Override
         public void encode(IonWriter writer, Block block, int position)
                 throws IOException
@@ -179,13 +190,7 @@ public class IonEncoderFactory
             writer.stepIn(IonType.STRUCT);
             for (int i = 0; i < sqlMap.getSize(); i++) {
                 checkArgument(!rawKeyBlock.isNull(rawOffset + i), "map key is null");
-                if (keyType instanceof VarcharType _ || keyType instanceof CharType _) {
-                    writer.setFieldName(VarcharType.VARCHAR.getSlice(rawKeyBlock, rawOffset + i).toString(StandardCharsets.UTF_8));
-                }
-                else {
-                    throw new UnsupportedOperationException("Unsupported map key type: " + keyType);
-                }
-
+                writer.setFieldName(VarcharType.VARCHAR.getSlice(rawKeyBlock, rawOffset + i).toString(StandardCharsets.UTF_8));
                 encoder.encode(writer, rawValueBlock, rawOffset + i);
             }
             writer.stepOut();


### PR DESCRIPTION
## Description
This PR adds support for map type with string keys.

## List of change
* Adds `MapEncoder` and `MapDecoder` with support for `String`/`VARCHAR`/`CHAR` keys
* Adds test for map encoding and decoding
