### PR TITLE
Refactor IonDecoderFactory, Handle Dereference Paths

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/DecoderColumn.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/DecoderColumn.java
@@ -18,9 +18,14 @@ import io.trino.spi.type.Type;
 import java.util.List;
 import java.util.Optional;
 
-public record DecoderColumn(List<String> path, Type type, int position)
+public record DecoderColumn(List<DecoderPathStep> path, Type type, int position)
 {
-    Optional<String> head()
+    static DecoderColumn forFieldNamePath(List<String> path, Type type, int position)
+    {
+        return new DecoderColumn(path.stream().map(text -> (DecoderPathStep) new DecoderPathStep.FieldName(text)).toList(), type, position);
+    }
+
+    Optional<DecoderPathStep> head()
     {
         if (path.isEmpty()) {
             return Optional.empty();

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/DecoderColumn.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/DecoderColumn.java
@@ -13,18 +13,28 @@
  */
 package io.trino.hive.formats.ion;
 
-import com.amazon.ion.IonException;
-import com.amazon.ion.IonReader;
-import io.trino.spi.PageBuilder;
+import io.trino.spi.type.Type;
 
-public interface IonDecoder
+import java.util.List;
+import java.util.Optional;
+
+public record DecoderColumn(List<String> path, Type type, int position)
 {
-    /**
-     * Reads the _current_ top-level-value from the IonReader.
-     * <p>
-     * Expects that the calling code has called IonReader.next()
-     * to position the reader at the value to be decoded.
-     */
-    void decode(IonReader ionReader, PageBuilder pageBuilder)
-            throws IonException;
+    Optional<String> head()
+    {
+        if (path.isEmpty()) {
+            return Optional.empty();
+        }
+        else {
+            return Optional.of(path.getFirst());
+        }
+    }
+
+    DecoderColumn tail()
+    {
+        if (path.isEmpty()) {
+            throw new IllegalArgumentException("Cannot take tail of empty path!");
+        }
+        return new DecoderColumn(path.subList(1, path.size()), type, position);
+    }
 }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/DecoderInstructions.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/DecoderInstructions.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.ion;
+
+import io.trino.spi.type.Type;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Models a tree of instructions to build an `IonDecoder` from.
+ * Defines a single abstraction to capture both the ion path extractions and Trino dereferencing.
+ */
+public sealed interface DecoderInstructions
+{
+    record DecodeValue(Type type, Integer blockPosition)
+            implements DecoderInstructions {}
+
+    record StructFields(Map<String, DecoderInstructions> fields)
+            implements DecoderInstructions
+    {
+        StructFields fold(String fieldName, DecoderColumn tail)
+        {
+            DecoderInstructions existing = fields.getOrDefault(fieldName, EMPTY);
+            HashMap<String, DecoderInstructions> merged = new HashMap<>(fields);
+            merged.put(fieldName, existing.fold(tail));
+
+            return new StructFields(Collections.unmodifiableMap(merged));
+        }
+    }
+
+    record Empty()
+            implements DecoderInstructions {}
+
+    Empty EMPTY = new Empty();
+    StructFields EMPTY_STRUCT = new StructFields(Map.of());
+
+    static DecoderInstructions forColumns(List<DecoderColumn> columns)
+    {
+        DecoderInstructions instructions = EMPTY;
+        for (DecoderColumn column : columns) {
+            instructions = instructions.fold(column);
+        }
+
+        return instructions;
+    }
+
+    /**
+     * fold the `column` into this, returning a new DecoderInstructions which has merged
+     * the new column into the instructions.
+     */
+    default DecoderInstructions fold(
+            DecoderColumn column)
+    {
+        Optional<String> head = column.head();
+        if (head.isEmpty()) {
+            checkArgument(this instanceof Empty, "Cannot cover steps or other column with decoded column!");
+            return new DecodeValue(column.type(), column.position());
+        }
+
+        String step = head.get();
+        DecoderColumn tail = column.tail();
+        return switch (this) {
+            case Empty _ -> EMPTY_STRUCT.fold(step, tail);
+            case StructFields struct -> struct.fold(step, tail);
+            case DecodeValue _ -> throw new IllegalArgumentException("Cannot merge steps into covering decoded column!");
+        };
+    }
+}

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/DecoderPathStep.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/DecoderPathStep.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.ion;
+
+public sealed interface DecoderPathStep
+{
+    record FieldName(String name) implements DecoderPathStep {}
+
+    record ListIndex(Integer ordinal) implements DecoderPathStep {}
+}

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
@@ -211,7 +211,7 @@ public class TestIonFormat
     public void testDereferencedFieldInNestedRow()
             throws IOException
     {
-        DecoderColumn column = new DecoderColumn(
+        DecoderColumn column = DecoderColumn.forFieldNamePath(
                 List.of("name", "first"),
                 VARCHAR,
                 0);
@@ -244,11 +244,11 @@ public class TestIonFormat
             throws IOException
     {
         List<DecoderColumn> columns = List.of(
-                new DecoderColumn(
+                DecoderColumn.forFieldNamePath(
                         List.of("name", "first"),
                         VARCHAR,
                         0),
-                new DecoderColumn(
+                DecoderColumn.forFieldNamePath(
                         List.of("name", "last"),
                         VARCHAR,
                         1));
@@ -354,7 +354,7 @@ public class TestIonFormat
         for (int i = 0; i < fields.size(); i++) {
             RowType.Field field = fields.get(i);
             Type type = field.getType();
-            decoderColumns.add(new DecoderColumn(List.of(field.getName().get()), type, i));
+            decoderColumns.add(DecoderColumn.forFieldNamePath(List.of(field.getName().get()), type, i));
             columns.add(new Column(field.getName().get(), type, i));
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/PathExtractionConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/PathExtractionConfig.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.ion;
+
+import com.amazon.ion.IonReader;
+import com.amazon.ion.IonType;
+import com.amazon.ion.system.IonReaderBuilder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.HiveColumnHandle;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+class PathExtractionConfig
+{
+    private static final IonReaderBuilder readerBuilder = IonReaderBuilder.standard();
+
+    private PathExtractionConfig() {}
+
+    /**
+     * Finds an Ion Path Extractor if one is defined in the table's serde properties.
+     * If not found, a list containing the columnName is returned.
+     */
+    static Map<String, List<String>> getIonPathToColumn(List<HiveColumnHandle> columns, Map<String, String> tableProperties)
+    {
+        ImmutableMap.Builder<String, List<String>> extractionsBuilder = ImmutableMap.builder();
+
+        for (HiveColumnHandle columnHandle : columns) {
+            String columnName = columnHandle.getBaseColumnName();
+            String extractorDef = tableProperties.get("ion.%s.path_extractor".formatted(columnName));
+            if (extractorDef == null) {
+                extractionsBuilder.put(columnName, List.of(columnName));
+            }
+            else {
+                List<String> path = parsePath(extractorDef);
+                extractionsBuilder.put(columnName, path);
+            }
+        }
+
+        // we may have multiple columns with the same base column name
+        // they will have the same path
+        return extractionsBuilder.buildKeepingLast();
+    }
+
+    /**
+     * This copies the relatively simple logic of parsing paths from the path extractor
+     * configs from the ion-java-path-extraction.
+     * Using that was.... todo: fill in
+     */
+    private static List<String> parsePath(String path)
+    {
+        try (IonReader reader = readerBuilder.build(path)) {
+            IonType containerType = reader.next();
+
+            checkArgument(containerType != null, "search path must not be null");
+            checkArgument(containerType.equals(IonType.LIST) || containerType.equals(IonType.SEXP),
+                    "search path must be an Ion sequence");
+            validateNoAnnotations(reader);
+
+            reader.stepIn();
+            ImmutableList.Builder<String> builder = ImmutableList.builder();
+            while (reader.next() != null) {
+                validateNoAnnotations(reader);
+                builder.add(parseStep(reader));
+            }
+            reader.stepOut();
+
+            return builder.build();
+        }
+        catch (IOException e) {
+            throw new IllegalStateException("not reachable", e);
+        }
+    }
+
+    private static void validateNoAnnotations(IonReader reader)
+    {
+        if (reader.getTypeAnnotations().length > 0) {
+            throw new UnsupportedPathException("annotation matching is not supported!");
+        }
+    }
+
+    private static String parseStep(IonReader reader)
+    {
+        return switch (reader.getType()) {
+            case IonType.INT -> throw new UnsupportedPathException("Sequence index extractions are not supported!");
+            case IonType.STRING, IonType.SYMBOL -> {
+                String text = reader.stringValue();
+                if (text.equals("*")) {
+                    throw new UnsupportedPathException("Wildcard matching is not supported!");
+                }
+                yield text;
+            }
+            default -> throw new IllegalArgumentException("Path step must be IonText (field name)");
+        };
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/UnsupportedPathException.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/UnsupportedPathException.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.ion;
+
+/**
+ * Indicates a specific path extraction path that is supported by the
+ * legacy hive implementation but not (yet) by the native trino impl.
+ */
+public class UnsupportedPathException
+        extends IllegalArgumentException
+{
+    public UnsupportedPathException(String message)
+    {
+        super(message);
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/ion/IonPageSourceSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/ion/IonPageSourceSmokeTest.java
@@ -73,6 +73,8 @@ import static java.util.stream.Collectors.toList;
 
 /**
  * Most basic test to reflect PageSource-fu is wired up correctly.
+ * More comprehensive tests, with assertions on values are in the TestIonFormat test
+ * in the lib/trino-hive sub-module.
  */
 public class IonPageSourceSmokeTest
 {
@@ -113,7 +115,7 @@ public class IonPageSourceSmokeTest
     }
 
     @Test
-    public void testProjectedColumn()
+    public void testNestedProjection()
             throws IOException
     {
         final RowType spamType = RowType.rowType(field("nested_to_prune", INTEGER), field("eggs", INTEGER));
@@ -126,10 +128,8 @@ public class IonPageSourceSmokeTest
         assertRowCount(
                 tableColumns,
                 projectedColumns,
-                // the data below reflects that "ham" is not decoded, that column is pruned
-                // "nested_to_prune" is decoded, however, because nested fields are not pruned, yet.
-                // so this test will fail if you change that to something other than an int
-                "{ spam: { nested_to_prune: 31, eggs: 12 }, ham: exploding }",
+                // decoding either 'ham' or 'nested_to_prune' would result in an error
+                "{ spam: { nested_to_prune: splodysplode, eggs: 12 }, ham: exploding }",
                 1);
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/ion/IonPageSourceSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/ion/IonPageSourceSmokeTest.java
@@ -172,6 +172,24 @@ public class IonPageSourceSmokeTest
     }
 
     @Test
+    public void testPathExtractionWithIndexedListItems()
+            throws IOException
+    {
+        List<HiveColumnHandle> tableColumns = List.of(
+                toHiveBaseColumnHandle("cell", VARCHAR, 0),
+                toHiveBaseColumnHandle("home", VARCHAR, 1));
+
+        TestFixture fixture = new TestFixture(tableColumns)
+                .withPathExtractor("cell", "(phone 0)")
+                .withPathExtractor("home", "(phone 2)");
+
+        assertRowValues(
+                fixture,
+                "{ phone: ['999-555-1212', '999-999-9999', '999-555-3434'] }",
+                List.of("999-555-1212", "999-555-3434"));
+    }
+
+    @Test
     public void testPathExtractTopLevelValue()
             throws IOException
     {
@@ -296,7 +314,6 @@ public class IonPageSourceSmokeTest
                     pageSource,
                     fixture.projections.stream().map(HiveColumnHandle::getType).toList());
             Assertions.assertEquals(rowCount, result.getRowCount());
-            result.getMaterializedRows().forEach(System.err::println);
         }
     }
 


### PR DESCRIPTION
This change refactors IonDecoderFactory to enable decoders that don't
actually write to block themselves but are parents of other decoders.
I used new abstractions and refactored implementation to handle trino
dereference pushdown; with this change we also prune nested structs.
It should be straightforward to make this work for field name pathing.

The abstractions are designed to handle the two additional use-cases
from path extraction we need to support:
1. Capturing a top-level Ion value as the single column of the Table.
2. Extracting values from lists with ordinal indexes.

Subsequent changes will make those work by SerDe Properties as today.

I also took the opportunity to handle correctly typed and untyped null
top-level-values as the hive serde does. A mistyped top-level value,
whether null or not is still an error, though it is not in ion hive.
That too will be addressed in a subsequent change.
