### PR TITLE
Omit null fields instead of encoding them as null.

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
@@ -145,12 +145,13 @@ public class IonEncoderFactory
             writer.stepIn(IonType.STRUCT);
             for (int i = 0; i < fieldEncoders.size(); i++) {
                 // Omit the filed when the field is null
-                if (blockSelector.apply(i).isNull(position)) {
+                Block block = blockSelector.apply(i);
+                if (block.isNull(position)) {
                     continue;
                 }
                 writer.setFieldName(fieldNames.get(i));
                 fieldEncoders.get(i)
-                        .encode(writer, blockSelector.apply(i), position);
+                        .encode(writer, block, position);
             }
             writer.stepOut();
         }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
@@ -144,7 +144,10 @@ public class IonEncoderFactory
         {
             writer.stepIn(IonType.STRUCT);
             for (int i = 0; i < fieldEncoders.size(); i++) {
-                // todo: the Hive SerDe omits fields when null by default
+                // Omit the filed when the field is null
+                if (blockSelector.apply(i).isNull(position)) {
+                    continue;
+                }
                 writer.setFieldName(fieldNames.get(i));
                 fieldEncoders.get(i)
                         .encode(writer, blockSelector.apply(i), position);

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -53,6 +54,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestIonFormat
 {
+    private static final List<Column> TEST_COLUMNS = List.of(
+            new Column("magic_num", INTEGER, 0),
+            new Column("some_text", VARCHAR, 1),
+            new Column("is_summer", BooleanType.BOOLEAN, 2),
+            new Column("byte_clob", VarbinaryType.VARBINARY, 3),
+            new Column("sequencer", new ArrayType(INTEGER), 4),
+            new Column("struction", RowType.rowType(
+                    field("foo", INTEGER),
+                    field("bar", VARCHAR)), 5));
+
     @Test
     public void testSuperBasicStruct()
             throws IOException
@@ -210,16 +221,6 @@ public class TestIonFormat
     public void testEncode()
             throws IOException
     {
-        List<Column> columns = List.of(
-                new Column("magic_num", INTEGER, 0),
-                new Column("some_text", VARCHAR, 1),
-                new Column("is_summer", BooleanType.BOOLEAN, 2),
-                new Column("byte_clob", VarbinaryType.VARBINARY, 3),
-                new Column("sequencer", new ArrayType(INTEGER), 4),
-                new Column("struction", RowType.rowType(
-                        field("foo", INTEGER),
-                        field("bar", VARCHAR)), 5));
-
         List<Object> row1 = List.of(17, "something", true, new SqlVarbinary(new byte[] {(byte) 0xff}), List.of(1, 2, 3), List.of(51, "baz"));
         List<Object> row2 = List.of(31, "somebody", false, new SqlVarbinary(new byte[] {(byte) 0x01, (byte) 0xaa}), List.of(7, 8, 9), List.of(67, "qux"));
         String ionText = """
@@ -227,8 +228,38 @@ public class TestIonFormat
                 { magic_num:31, some_text:"somebody", is_summer:false, byte_clob:{{Aao=}}, sequencer:[7,8,9], struction:{ foo:67, bar:"qux"}}
                 """;
 
-        Page page = toPage(columns, row1, row2);
-        assertIonEquivalence(columns, page, ionText);
+        Page page = toPage(TEST_COLUMNS, row1, row2);
+        assertIonEquivalence(TEST_COLUMNS, page, ionText);
+    }
+
+    @Test
+    public void testEncodeWithNullField()
+            throws IOException
+    {
+        List<Object> row1 = Arrays.asList(null, "something", true, new SqlVarbinary(new byte[] {(byte) 0xff}), List.of(1, 2, 3), List.of(51, "baz"));
+        List<Object> row2 = Arrays.asList(31, "somebody", null, new SqlVarbinary(new byte[] {(byte) 0x01, (byte) 0xaa}), List.of(7, 8, 9), List.of(67, "qux"));
+        String ionText = """
+                { some_text:"something", is_summer:true, byte_clob:{{/w==}}, sequencer:[1,2,3], struction:{ foo:51, bar:"baz"}}
+                { magic_num:31, some_text:"somebody", byte_clob:{{Aao=}}, sequencer:[7,8,9], struction:{ foo:67, bar:"qux"}}
+                """;
+
+        Page page = toPage(TEST_COLUMNS, row1, row2);
+        assertIonEquivalence(TEST_COLUMNS, page, ionText);
+    }
+
+    @Test
+    public void testEncodeWithNullNestedField()
+            throws IOException
+    {
+        List<Object> row1 = Arrays.asList(17, "something", true, new SqlVarbinary(new byte[] {(byte) 0xff}), List.of(1, 2, 3), Arrays.asList(null, "baz"));
+        List<Object> row2 = Arrays.asList(31, "somebody", null, new SqlVarbinary(new byte[] {(byte) 0x01, (byte) 0xaa}), List.of(7, 8, 9), Arrays.asList(null, "qux"));
+        String ionText = """
+                { magic_num:17, some_text:"something", is_summer:true, byte_clob:{{/w==}}, sequencer:[1,2,3], struction:{bar:"baz"}}
+                { magic_num:31, some_text:"somebody", byte_clob:{{Aao=}}, sequencer:[7,8,9], struction:{bar:"qux"}}
+                """;
+
+        Page page = toPage(TEST_COLUMNS, row1, row2);
+        assertIonEquivalence(TEST_COLUMNS, page, ionText);
     }
 
     private void assertValues(RowType rowType, String ionText, List<Object>... expected)

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
@@ -236,14 +236,12 @@ public class TestIonFormat
     public void testEncodeWithNullField()
             throws IOException
     {
-        List<Object> row1 = Arrays.asList(null, "something", true, new SqlVarbinary(new byte[] {(byte) 0xff}), List.of(1, 2, 3), List.of(51, "baz"));
-        List<Object> row2 = Arrays.asList(31, "somebody", null, new SqlVarbinary(new byte[] {(byte) 0x01, (byte) 0xaa}), List.of(7, 8, 9), List.of(67, "qux"));
+        List<Object> row1 = Arrays.asList(null, null, null, null, null, null);
         String ionText = """
-                { some_text:"something", is_summer:true, byte_clob:{{/w==}}, sequencer:[1,2,3], struction:{ foo:51, bar:"baz"}}
-                { magic_num:31, some_text:"somebody", byte_clob:{{Aao=}}, sequencer:[7,8,9], struction:{ foo:67, bar:"qux"}}
+                {}
                 """;
 
-        Page page = toPage(TEST_COLUMNS, row1, row2);
+        Page page = toPage(TEST_COLUMNS, row1);
         assertIonEquivalence(TEST_COLUMNS, page, ionText);
     }
 


### PR DESCRIPTION
### Changes:
Modified struct encoding to omit null fields rather than encoding them as null values


### Tests:
* Test null field omission in top-level structs
* Test null field omission in nested structs