### PR TITLE
Change Handling of Some Mistypings and Oversized Values

### DIFF
--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/FormatTestUtils.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/FormatTestUtils.java
@@ -666,6 +666,11 @@ public final class FormatTestUtils
 
     public static SqlTimestamp toSqlTimestamp(TimestampType timestampType, LocalDateTime localDateTime)
     {
+        return toSqlTimestamp(timestampType, localDateTime, 0);
+    }
+
+    public static SqlTimestamp toSqlTimestamp(TimestampType timestampType, LocalDateTime localDateTime, int picosOfNanos)
+    {
         if (localDateTime == null) {
             return null;
         }
@@ -675,7 +680,7 @@ public final class FormatTestUtils
             return SqlTimestamp.newInstance(timestampType.getPrecision(), micros, 0);
         }
         LongTimestamp longTimestamp = (LongTimestamp) createTimestampEncoder(timestampType, DateTimeZone.UTC).getTimestamp(decodedTimestamp);
-        return SqlTimestamp.newInstance(timestampType.getPrecision(), longTimestamp.getEpochMicros(), longTimestamp.getPicosOfMicro());
+        return SqlTimestamp.newInstance(timestampType.getPrecision(), longTimestamp.getEpochMicros(), longTimestamp.getPicosOfMicro() + picosOfNanos);
     }
 
     public static LineBuffer createLineBuffer(String value)


### PR DESCRIPTION
This commit has a few changes to edges in handling of mistyped or
oversized values. Each change either brings this impl in line with
Ion Hive or makes it stricter.

* IonInts are coerced to Decimals (as Ion Hive does)
* Timestamps are truncated when overprecise or being coerced to Dates
  (as Ion Hive does, see note below)
* Decimals with more whole digits than fit is now an error
  (oddly this is not an error in Ion Hive)
* TrinoExceptions are thrown for a few cases

Fairly exhaustive test cases were added for each of the changes.

A note about rounding vs truncating Timestamps: the SQL standard
says that it's implementation defined what to do here. For me,
the fact that a timestamp of 2023-12-31 23:59:59.999999Z would
be rounded into 2024 is just too surprising to consider correct.
So, given that and that the legacy behavior is to truncate, that
seems correct to me.
