### PR TITLE
Enable Strict or Lax Path Typing

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSourceFactory.java
@@ -137,7 +137,8 @@ public class IonPageSourceFactory
             List<Column> decoderColumns = projectedReaderColumns.stream()
                     .map(hc -> new Column(hc.getName(), hc.getType(), hc.getBaseHiveColumnIndex()))
                     .toList();
-            IonDecoder decoder = IonDecoderFactory.buildDecoder(decoderColumns);
+            boolean strictPathing = IonReaderOptions.useStrictPathTyping(schema.serdeProperties());
+            IonDecoder decoder = IonDecoderFactory.buildDecoder(decoderColumns, strictPathing);
             IonPageSource pageSource = new IonPageSource(ionReader, countingInputStream::getCount, decoder, pageBuilder);
 
             return Optional.of(new ReaderPageSource(pageSource, readerProjections));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonReaderOptions.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonReaderOptions.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.ion;
+
+import java.util.Map;
+
+public final class IonReaderOptions
+{
+    public static final String STRICT_PATH_TYPING_PROPERTY = "ion.path_extractor.strict";
+    public static final String STRICT_PATH_TYPING_DEFAULT = "false";
+
+    private IonReaderOptions() {}
+
+    static boolean useStrictPathTyping(Map<String, String> propertiesMap)
+    {
+        return Boolean.parseBoolean(
+                propertiesMap.getOrDefault(STRICT_PATH_TYPING_PROPERTY, STRICT_PATH_TYPING_DEFAULT));
+    }
+}


### PR DESCRIPTION
This change adds a SerDe Property to support non-strict path typing.
It defaults to false to mimic the behavior of the ion-hive-serde
which used path extraction for the top-level-values, whether the user
had defined any extractions or not. Without support for pathing
this is effectively a type-check (or not) for TLVs. With support for
extraction the behavior is a little more subtle than that, so I named
the property for how it will behave. The name is also consistent with
other properties.

I also added some tests for nested mistypings and changed the code
to consistently throw TrinoExceptions.
