### PR TITLE
Return empty PageSource when there's unsupported Serde property

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSourceFactory.java
@@ -79,14 +79,14 @@ public class IonPageSourceFactory
     // this is used as a feature flag to enable Ion native trino integration
     private final boolean nativeTrinoEnabled;
 
-    private static final Map<String, String> EXACT_PROPERTIES = ImmutableMap.of(
+    private static final Map<String, String> TABLE_PROPERTIES = ImmutableMap.of(
             FAIL_ON_OVERFLOW_PROPERTY, FAIL_ON_OVERFLOW_PROPERTY_DEFAULT,
             IGNORE_MALFORMED, IGNORE_MALFORMED_DEFAULT,
             PATH_EXTRACTION_CASE_SENSITIVITY, PATH_EXTRACTION_CASE_SENSITIVITY_DEFAULT,
             ION_TIMESTAMP_OFFSET_PROPERTY, ION_TIMESTAMP_OFFSET_DEFAULT,
             ION_SERIALIZATION_AS_NULL_PROPERTY, ION_SERIALIZATION_AS_NULL_DEFAULT);
 
-    private static final Set<Pattern> PATTERN_PROPERTIES = ImmutableSet.of(
+    private static final Set<Pattern> COLUMN_PROPERTIES = ImmutableSet.of(
             Pattern.compile(FAIL_ON_OVERFLOW_PROPERTY_WITH_COLUMN),
             Pattern.compile(ION_SERIALIZATION_AS_PROPERTY),
             Pattern.compile(PATH_EXTRACTOR_PROPERTY));
@@ -188,14 +188,14 @@ public class IonPageSourceFactory
         String key = entry.getKey();
         String value = entry.getValue();
 
-        // Check exact matches
-        String propertyDefault = EXACT_PROPERTIES.get(key);
+        String propertyDefault = TABLE_PROPERTIES.get(key);
         if (propertyDefault != null) {
             return !propertyDefault.equals(value);
         }
 
-        // Check pattern matches
-        return PATTERN_PROPERTIES.stream()
+        // For now, any column-specific properties result in an empty PageSource
+        // since they have no default values for comparison.
+        return COLUMN_PROPERTIES.stream()
                 .anyMatch(pattern -> pattern.matcher(key).matches());
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSourceFactory.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive.ion;
 
 import com.amazon.ion.IonReader;
 import com.amazon.ion.system.IonReaderBuilder;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.io.CountingInputStream;
 import com.google.inject.Inject;
 import io.trino.filesystem.Location;
@@ -45,6 +46,8 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -52,6 +55,14 @@ import static io.trino.hive.formats.HiveClassNames.ION_SERDE_CLASS;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
 import static io.trino.plugin.hive.HivePageSourceProvider.projectBaseColumns;
 import static io.trino.plugin.hive.ReaderPageSource.noProjectionAdaptation;
+import static io.trino.plugin.hive.ion.IonReaderOptions.FAIL_ON_OVERFLOW_PROPERTY;
+import static io.trino.plugin.hive.ion.IonReaderOptions.FAIL_ON_OVERFLOW_PROPERTY_WITH_COLUMN;
+import static io.trino.plugin.hive.ion.IonReaderOptions.IGNORE_MALFORMED;
+import static io.trino.plugin.hive.ion.IonReaderOptions.PATH_EXTRACTION_CASE_SENSITIVITY;
+import static io.trino.plugin.hive.ion.IonReaderOptions.PATH_EXTRACTOR_PROPERTY;
+import static io.trino.plugin.hive.ion.IonWriterOptions.ION_SERIALIZATION_AS_NULL_PROPERTY;
+import static io.trino.plugin.hive.ion.IonWriterOptions.ION_SERIALIZATION_AS_PROPERTY;
+import static io.trino.plugin.hive.ion.IonWriterOptions.ION_TIMESTAMP_OFFSET_PROPERTY;
 import static io.trino.plugin.hive.util.HiveUtil.splitError;
 
 public class IonPageSourceFactory
@@ -60,6 +71,16 @@ public class IonPageSourceFactory
     private final TrinoFileSystemFactory trinoFileSystemFactory;
     // this is used as a feature flag to enable Ion native trino integration
     private final boolean nativeTrinoEnabled;
+
+    private static final Set<String> UNSUPPORTED_SERDE_PROPERTIES = ImmutableSet.of(
+            FAIL_ON_OVERFLOW_PROPERTY,
+            FAIL_ON_OVERFLOW_PROPERTY_WITH_COLUMN,
+            PATH_EXTRACTOR_PROPERTY,
+            PATH_EXTRACTION_CASE_SENSITIVITY,
+            IGNORE_MALFORMED,
+            ION_TIMESTAMP_OFFSET_PROPERTY,
+            ION_SERIALIZATION_AS_NULL_PROPERTY,
+            ION_SERIALIZATION_AS_PROPERTY);
 
     @Inject
     public IonPageSourceFactory(TrinoFileSystemFactory trinoFileSystemFactory, HiveConfig hiveConfig)
@@ -89,6 +110,11 @@ public class IonPageSourceFactory
             // on their use case
             return Optional.empty();
         }
+
+        if (schema.serdeProperties().entrySet().stream().anyMatch(entry -> isUnsupportedProperty(entry.getKey()))) {
+            return Optional.empty();
+        }
+
         if (!ION_SERDE_CLASS.equals(schema.serializationLibraryName())) {
             return Optional.empty();
         }
@@ -146,5 +172,16 @@ public class IonPageSourceFactory
         catch (IOException e) {
             throw new TrinoException(HIVE_CANNOT_OPEN_SPLIT, splitError(e, path, start, length), e);
         }
+    }
+
+    private boolean isUnsupportedProperty(String property)
+    {
+        return UNSUPPORTED_SERDE_PROPERTIES.stream()
+                .anyMatch(pattern -> {
+                    if (pattern.contains("\\w+")) {
+                        return Pattern.compile(pattern).matcher(property).matches();
+                    }
+                    return pattern.equals(property);
+                });
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonReaderOptions.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonReaderOptions.java
@@ -18,12 +18,15 @@ import java.util.Map;
 public final class IonReaderOptions
 {
     public static final String STRICT_PATH_TYPING_PROPERTY = "ion.path_extractor.strict";
+    public static final String STRICT_PATH_TYPING_DEFAULT = "false";
     public static final String PATH_EXTRACTOR_PROPERTY = "ion.\\w+.path_extractor";
     public static final String PATH_EXTRACTION_CASE_SENSITIVITY = "ion.path_extractor.case_sensitive";
+    public static final String PATH_EXTRACTION_CASE_SENSITIVITY_DEFAULT = "false";
     public static final String FAIL_ON_OVERFLOW_PROPERTY_WITH_COLUMN = "ion.\\w+.fail_on_overflow";
     public static final String FAIL_ON_OVERFLOW_PROPERTY = "ion.fail_on_overflow";
+    public static final String FAIL_ON_OVERFLOW_PROPERTY_DEFAULT = "true";
     public static final String IGNORE_MALFORMED = "ion.ignore_malformed";
-    public static final String STRICT_PATH_TYPING_DEFAULT = "false";
+    public static final String IGNORE_MALFORMED_DEFAULT = "false";
 
     private IonReaderOptions() {}
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonReaderOptions.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonReaderOptions.java
@@ -18,6 +18,11 @@ import java.util.Map;
 public final class IonReaderOptions
 {
     public static final String STRICT_PATH_TYPING_PROPERTY = "ion.path_extractor.strict";
+    public static final String PATH_EXTRACTOR_PROPERTY = "ion.\\w+.path_extractor";
+    public static final String PATH_EXTRACTION_CASE_SENSITIVITY = "ion.path_extractor.case_sensitive";
+    public static final String FAIL_ON_OVERFLOW_PROPERTY_WITH_COLUMN = "ion.\\w+.fail_on_overflow";
+    public static final String FAIL_ON_OVERFLOW_PROPERTY = "ion.fail_on_overflow";
+    public static final String IGNORE_MALFORMED = "ion.ignore_malformed";
     public static final String STRICT_PATH_TYPING_DEFAULT = "false";
 
     private IonReaderOptions() {}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonWriterOptions.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonWriterOptions.java
@@ -28,7 +28,9 @@ public final class IonWriterOptions
 {
     public static final String ION_ENCODING_PROPERTY = "ion.encoding";
     public static final String ION_TIMESTAMP_OFFSET_PROPERTY = "ion.timestamp.serialization_offset";
+    public static final String ION_TIMESTAMP_OFFSET_DEFAULT = "Z";
     public static final String ION_SERIALIZATION_AS_NULL_PROPERTY = "ion.serialize_null";
+    public static final String ION_SERIALIZATION_AS_NULL_DEFAULT = "OMIT";
     public static final String ION_SERIALIZATION_AS_PROPERTY = "ion.\\w+.serialize_as";
 
     public static final String TEXT_ENCODING = "text";

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonWriterOptions.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonWriterOptions.java
@@ -27,6 +27,10 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
 public final class IonWriterOptions
 {
     public static final String ION_ENCODING_PROPERTY = "ion.encoding";
+    public static final String ION_TIMESTAMP_OFFSET_PROPERTY = "ion.timestamp.serialization_offset";
+    public static final String ION_SERIALIZATION_AS_NULL_PROPERTY = "ion.serialize_null";
+    public static final String ION_SERIALIZATION_AS_PROPERTY = "ion.\\w+.serialize_as";
+
     public static final String TEXT_ENCODING = "text";
     public static final String BINARY_ENCODING = "binary";
 


### PR DESCRIPTION
This change checks if the configuration contains unsupported Serde properties. If there's an unsupported property included, it will return an empty `PageSource`.

_**Unsupported properties:**_

- `ion.serialize_null`
- `ion.fail_on_overflow`
- `ion.<column>.fail_on_overflow`
- `ion.ignore_malformed`
- `ion.<column>.serialize_as`
- `ion.timestamp.serialization_offset`
- `ion.<column>.path_extractor`
- `ion.path_extractor.case_sensitive`
