### PR TITLE
Minor Fixups

### DIFF
--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonEncoderFactory.java
@@ -51,7 +51,6 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.function.IntFunction;
 
@@ -64,7 +63,7 @@ public class IonEncoderFactory
     public static IonEncoder buildEncoder(List<Column> columns)
     {
         return RowEncoder.forFields(columns.stream()
-                .map(c -> new RowType.Field(Optional.of(c.name().toLowerCase(Locale.ROOT)), c.type()))
+                .map(c -> new RowType.Field(Optional.of(c.name()), c.type()))
                 .toList());
     }
 
@@ -89,8 +88,7 @@ public class IonEncoderFactory
             case DecimalType t -> decimalEncoder(t);
             case DateType _ -> dateEncoder;
             case TimestampType t -> timestampEncoder(t);
-            case MapType t -> new MapEncoder(t, t.getKeyType(),
-                    encoderForType(t.getValueType()));
+            case MapType t -> new MapEncoder(t, t.getKeyType(), encoderForType(t.getValueType()));
             case RowType t -> RowEncoder.forFields(t.getFields());
             case ArrayType t -> new ArrayEncoder(wrapEncoder(encoderForType(t.getElementType())));
             default -> throw new IllegalArgumentException(String.format("Unsupported type: %s", type));
@@ -119,7 +117,7 @@ public class IonEncoderFactory
             ImmutableList.Builder<BlockEncoder> fieldEncodersBuilder = ImmutableList.builder();
 
             for (RowType.Field field : fields) {
-                fieldNamesBuilder.add(field.getName().get().toLowerCase(Locale.ROOT));
+                fieldNamesBuilder.add(field.getName().get());
                 fieldEncodersBuilder.add(wrapEncoder(encoderForType(field.getType())));
             }
 

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
@@ -436,6 +436,27 @@ public class TestIonFormat
     }
 
     @Test
+    public void testEncodeTimestamp()
+            throws IOException
+    {
+        List<Column> timestampColumn = List.of(new Column("my_ts", TimestampType.TIMESTAMP_NANOS, 0));
+        Page page = toPage(timestampColumn, List.of(
+                toSqlTimestamp(TimestampType.TIMESTAMP_NANOS, LocalDateTime.of(2024, 11, 23, 1, 23, 45, 666777888))));
+        assertIonEquivalence(timestampColumn, page, "{ my_ts: 2024-11-23T01:23:45.666777888Z }");
+    }
+
+    @Test
+    public void testEncodeMixedCaseColumn()
+            throws IOException
+    {
+        List<Column> casedColumn = List.of(
+                new Column("TheAnswer", INTEGER, 0));
+
+        Page page = toPage(casedColumn, List.of(42));
+        assertIonEquivalence(casedColumn, page, "{ TheAnswer: 42 }");
+    }
+
+    @Test
     public void testEncodeWithNullField()
             throws IOException
     {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonFileWriter.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import java.util.function.LongSupplier;
 
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_DATA_ERROR;
 
 public class IonFileWriter
         implements FileWriter
@@ -106,7 +107,7 @@ public class IonFileWriter
             writer.close();
         }
         catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new TrinoException(HIVE_WRITER_CLOSE_ERROR, "Error rolling back write to Hive", e);
         }
     }
 
@@ -123,7 +124,7 @@ public class IonFileWriter
             pageEncoder.encode(writer, page);
         }
         catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new TrinoException(HIVE_WRITER_DATA_ERROR, e);
         }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonFileWriterFactory.java
@@ -85,8 +85,6 @@ public class IonFileWriterFactory
 
             Closeable rollbackAction = () -> fileSystem.deleteFile(location);
 
-            // we take the column names from the schema, not what was input
-            // this is what the LineWriterFactory does, I don't understand why
             List<String> fileColumnNames = getColumnNames(schema);
             List<Type> fileColumnTypes = getColumnTypes(schema).stream()
                     .map(hiveType -> getType(hiveType, typeManager, getTimestampPrecision(session)))

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -139,7 +139,6 @@ import static io.trino.plugin.base.type.TrinoTimestampEncoderFactory.createTimes
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
-import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static io.trino.plugin.hive.HivePageSourceProvider.ColumnMapping.buildColumnMappings;
 import static io.trino.plugin.hive.HivePartitionKey.HIVE_DEFAULT_DYNAMIC_PARTITION;
 import static io.trino.plugin.hive.HiveStorageFormat.AVRO;
@@ -157,8 +156,6 @@ import static io.trino.plugin.hive.HiveTestUtils.SESSION;
 import static io.trino.plugin.hive.HiveTestUtils.getHiveSession;
 import static io.trino.plugin.hive.HiveTestUtils.mapType;
 import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
-import static io.trino.plugin.hive.ion.IonWriterOptions.ION_ENCODING_PROPERTY;
-import static io.trino.plugin.hive.ion.IonWriterOptions.TEXT_ENCODING;
 import static io.trino.plugin.hive.util.HiveTypeTranslator.toHiveType;
 import static io.trino.plugin.hive.util.SerdeConstants.LIST_COLUMNS;
 import static io.trino.plugin.hive.util.SerdeConstants.LIST_COLUMN_TYPES;
@@ -234,7 +231,6 @@ public final class TestHiveFileFormats
     private static final FileFormatDataSourceStats STATS = new FileFormatDataSourceStats();
     private static final ConnectorSession PARQUET_SESSION = getHiveSession(createParquetHiveConfig(false));
     private static final ConnectorSession PARQUET_SESSION_USE_NAME = getHiveSession(createParquetHiveConfig(true));
-    private static final String ERROR_ENCODING = "error_encoding";
 
     @DataProvider(name = "rowCount")
     public static Object[][] rowCountProvider()
@@ -377,7 +373,8 @@ public final class TestHiveFileFormats
             throws Exception
     {
         List<TestColumn> testColumns = TEST_COLUMNS.stream()
-                // todo: add support for maps to trino impl
+                // even though maps with text keys work with the native trino impl
+                // there is an error when testing against the hive serde
                 .filter(tc -> !(tc.type instanceof MapType))
                 .collect(toList());
 
@@ -392,54 +389,6 @@ public final class TestHiveFileFormats
                 .withFileSizePadding(fileSizePadding)
                 .withFileWriterFactory(fileSystemFactory -> new IonFileWriterFactory(fileSystemFactory, TESTING_TYPE_MANAGER))
                 .isReadableByPageSource(fileSystemFactory -> new IonPageSourceFactory(fileSystemFactory, hiveConfig));
-    }
-
-    @Test(dataProvider = "validRowAndFileSizePadding")
-    public void testIonWithTextEncoding(int rowCount, long fileSizePadding)
-            throws Exception
-    {
-        List<TestColumn> testColumns = TEST_COLUMNS.stream()
-                // todo: add support for maps to trino impl
-                .filter(tc -> !(tc.type instanceof MapType))
-                .collect(toList());
-
-        HiveConfig hiveConfig = new HiveConfig();
-        // enable Ion native trino integration for testing while the implementation is in progress
-        // TODO: In future this flag should change to `true` as default and then the following statement can be removed.
-        hiveConfig.setIonNativeTrinoEnabled(true);
-
-        assertThatFileFormat(ION)
-                .withColumns(testColumns)
-                .withRowsCount(rowCount)
-                .withFileSizePadding(fileSizePadding)
-                .withTableProperties(ImmutableMap.of(ION_ENCODING_PROPERTY, TEXT_ENCODING))
-                .withFileWriterFactory(fileSystemFactory -> new IonFileWriterFactory(fileSystemFactory, TESTING_TYPE_MANAGER))
-                .isReadableByPageSource(fileSystemFactory -> new IonPageSourceFactory(fileSystemFactory, hiveConfig));
-    }
-
-    @Test(dataProvider = "validRowAndFileSizePadding")
-    public void testInvalidIonEncoding(int rowCount, long fileSizePadding)
-            throws Exception
-    {
-        List<TestColumn> testColumns = TEST_COLUMNS.stream()
-                // todo: add support for maps to trino impl
-                .filter(tc -> !(tc.type instanceof MapType))
-                .collect(toList());
-
-        HiveConfig hiveConfig = new HiveConfig();
-        // enable Ion native trino integration for testing while the implementation is in progress
-        // TODO: In future this flag should change to `true` as default and then the following statement can be removed.
-        hiveConfig.setIonNativeTrinoEnabled(true);
-
-        assertTrinoExceptionThrownBy(() -> assertThatFileFormat(ION)
-                .withColumns(testColumns)
-                .withRowsCount(rowCount)
-                .withFileSizePadding(fileSizePadding)
-                .withTableProperties(ImmutableMap.of(ION_ENCODING_PROPERTY, ERROR_ENCODING))
-                .withFileWriterFactory(fileSystemFactory -> new IonFileWriterFactory(fileSystemFactory, TESTING_TYPE_MANAGER))
-                .isReadableByPageSource(fileSystemFactory -> new IonPageSourceFactory(fileSystemFactory, hiveConfig)))
-                .hasErrorCode(HIVE_WRITER_OPEN_ERROR)
-                .hasMessage("Error creating Ion Output");
     }
 
     @Test(dataProvider = "validRowAndFileSizePadding")
@@ -1275,7 +1224,6 @@ public final class TestHiveFileFormats
         private boolean skipGenericWrite;
         private HiveFileWriterFactory fileWriterFactory;
         private long fileSizePadding;
-        private Map<String, String> customTableProperties = ImmutableMap.of();
 
         private final TrinoFileSystemFactory fileSystemFactory = new MemoryFileSystemFactory();
 
@@ -1330,12 +1278,6 @@ public final class TestHiveFileFormats
         public FileFormatAssertion withRowsCount(int rowsCount)
         {
             this.rowsCount = rowsCount;
-            return this;
-        }
-
-        public FileFormatAssertion withTableProperties(Map<String, String> tableProperties)
-        {
-            this.customTableProperties = requireNonNull(tableProperties, "customTableProperties is null");
             return this;
         }
 
@@ -1397,7 +1339,7 @@ public final class TestHiveFileFormats
                         if (fileWriterFactory == null) {
                             continue;
                         }
-                        createTestFileTrino(location, storageFormat, compressionCodec, writeColumns, session, rowsCount, fileWriterFactory, customTableProperties);
+                        createTestFileTrino(location, storageFormat, compressionCodec, writeColumns, session, rowsCount, fileWriterFactory);
                     }
                     else {
                         if (skipGenericWrite) {
@@ -1427,8 +1369,7 @@ public final class TestHiveFileFormats
             List<TestColumn> testColumns,
             ConnectorSession session,
             int numRows,
-            HiveFileWriterFactory fileWriterFactory,
-            Map<String, String> customTableProperties)
+            HiveFileWriterFactory fileWriterFactory)
     {
         // filter out partition keys, which are not written to the file
         testColumns = testColumns.stream()
@@ -1453,7 +1394,6 @@ public final class TestHiveFileFormats
         Map<String, String> tableProperties = ImmutableMap.<String, String>builder()
                 .put(LIST_COLUMNS, testColumns.stream().map(TestColumn::name).collect(Collectors.joining(",")))
                 .put(LIST_COLUMN_TYPES, testColumns.stream().map(TestColumn::type).map(HiveTypeTranslator::toHiveType).map(HiveType::toString).collect(Collectors.joining(",")))
-                .putAll(customTableProperties)
                 .buildOrThrow();
 
         Optional<FileWriter> fileWriter = fileWriterFactory.createFileWriter(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/ion/IonPageSourceSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/ion/IonPageSourceSmokeTest.java
@@ -251,6 +251,16 @@ public class IonPageSourceSmokeTest
         assertEncoding(tableColumns, BINARY_ENCODING);
     }
 
+    @Test
+    public void testBadEncodingName()
+            throws IOException
+    {
+        TestFixture fixture = new TestFixture(FOO_BAR_COLUMNS)
+                .withEncoding("unknown_encoding_name");
+
+        Assertions.assertThrows(TrinoException.class, fixture::getFileWriter);
+    }
+
     private void assertEncoding(List<HiveColumnHandle> tableColumns,
             String encoding)
             throws IOException


### PR DESCRIPTION
This commit fixes up a few things I noticed when previewing the PR to
Trino.

* Column/Field name casing should be preserved when writing
* Some missing operational/metrics calls in IonPageSource
* Throw clearer Exception for errors in IonFileWriter
* Move some tests from TestHiveFileFormats to IonPageSourceSmokeTest
