### PR TITLE
Implement Path Extraction

### DIFF
--- a/lib/trino-hive-formats/pom.xml
+++ b/lib/trino-hive-formats/pom.xml
@@ -25,6 +25,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.amazon.ion</groupId>
+            <artifactId>ion-java-path-extraction</artifactId>
+            <version>1.5.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoder.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoder.java
@@ -15,7 +15,6 @@ package io.trino.hive.formats.ion;
 
 import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;
-import io.trino.spi.PageBuilder;
 
 public interface IonDecoder
 {
@@ -25,6 +24,6 @@ public interface IonDecoder
      * Expects that the calling code has called IonReader.next()
      * to position the reader at the value to be decoded.
      */
-    void decode(IonReader reader, PageBuilder builder)
+    void decode(IonReader reader)
             throws IonException;
 }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderConfig.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.hive.formats.ion;
+
+import java.util.Map;
+
+/**
+ * Captures the SerDe properties that affect decoding.
+ *
+ * @param pathExtractors Map of column name => ion paths
+ *        for each entry in the map, the value bound to the column will be the result
+ *        of extracting the given search path.
+ * @param strictTyping whether the path extractions should enforce type expectations.
+ *        this only affects type checking of path extractions; any value decoded into
+ *        a trino column will be correctly typed or coerced for that column.
+ */
+public record IonDecoderConfig(Map<String, String> pathExtractors, Boolean strictTyping)
+{
+    public static IonDecoderConfig defaultConfig()
+    {
+        return new IonDecoderConfig(Map.of(), false);
+    }
+}

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderConfig.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderConfig.java
@@ -24,11 +24,27 @@ import java.util.Map;
  * @param strictTyping whether the path extractions should enforce type expectations.
  *        this only affects type checking of path extractions; any value decoded into
  *        a trino column will be correctly typed or coerced for that column.
+ * @param caseSensitive whether field name matching should be case-sensitive or not.
  */
-public record IonDecoderConfig(Map<String, String> pathExtractors, Boolean strictTyping)
+public record IonDecoderConfig(Map<String, String> pathExtractors, Boolean strictTyping, Boolean caseSensitive)
 {
-    public static IonDecoderConfig defaultConfig()
+    static IonDecoderConfig defaultConfig()
     {
-        return new IonDecoderConfig(Map.of(), false);
+        return new IonDecoderConfig(Map.of(), false, false);
+    }
+
+    IonDecoderConfig withStrictTyping()
+    {
+        return new IonDecoderConfig(pathExtractors, true, caseSensitive);
+    }
+
+    IonDecoderConfig withCaseSensitive()
+    {
+        return new IonDecoderConfig(pathExtractors, strictTyping, true);
+    }
+
+    IonDecoderConfig withPathExtractors(Map<String, String> pathExtractors)
+    {
+        return new IonDecoderConfig(pathExtractors, strictTyping, caseSensitive);
     }
 }

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
@@ -87,7 +87,7 @@ public class IonDecoderFactory
             PageBuilder pageBuilder)
     {
         PathExtractorBuilder<PageExtractionContext> extractorBuilder = PathExtractorBuilder.<PageExtractionContext>standard()
-                .withMatchCaseInsensitive(true);
+                .withMatchCaseInsensitive(!decoderConfig.caseSensitive());
 
         for (int pos = 0; pos < columns.size(); pos++) {
             String name = columns.get(pos).name();

--- a/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
+++ b/lib/trino-hive-formats/src/main/java/io/trino/hive/formats/ion/IonDecoderFactory.java
@@ -17,11 +17,15 @@ import com.amazon.ion.IonException;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonType;
 import com.amazon.ion.Timestamp;
+import com.amazon.ionpathextraction.PathExtractor;
+import com.amazon.ionpathextraction.PathExtractorBuilder;
+import com.amazon.ionpathextraction.pathcomponents.Text;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slices;
 import io.trino.hive.formats.DistinctMapKeys;
 import io.trino.hive.formats.line.Column;
+import io.trino.spi.PageBuilder;
 import io.trino.spi.StandardErrorCode;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.ArrayBlockBuilder;
@@ -62,8 +66,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.IntFunction;
 
 public class IonDecoderFactory
@@ -76,37 +80,64 @@ public class IonDecoderFactory
      * The decoder expects to decode the _current_ Ion Value.
      * It also expects that the calling code will manage the PageBuilder.
      * <p>
-     *
-     * @param strictPathing controls behavior when encountering mistyped
-     * values during path extraction. That is outside (before), the trino
-     * type model. The ion-hive-serde used path extraction for navigating
-     * the top-level-values even if no path extractions were configured.
-     * So, in absence of support for path extraction configurations this
-     * still affects the handling of mistyped top-level-values.
-     * todo: revisit the above once path extraction config is supported.
      */
-    public static IonDecoder buildDecoder(List<Column> columns, boolean strictPathing)
+    public static IonDecoder buildDecoder(
+            List<Column> columns,
+            IonDecoderConfig decoderConfig,
+            PageBuilder pageBuilder)
     {
-        RowDecoder rowDecoder = RowDecoder.forFields(
-                columns.stream()
-                        .map(c -> new RowType.Field(Optional.of(c.name()), c.type()))
-                        .toList());
+        PathExtractorBuilder<PageExtractionContext> extractorBuilder = PathExtractorBuilder.<PageExtractionContext>standard()
+                .withMatchCaseInsensitive(true);
 
-        return (ionReader, pageBuilder) -> {
-            IonType ionType = ionReader.getType();
-            IntFunction<BlockBuilder> blockSelector = pageBuilder::getBlockBuilder;
+        for (int pos = 0; pos < columns.size(); pos++) {
+            String name = columns.get(pos).name();
+            BlockDecoder decoder = decoderForType(columns.get(pos).type());
+            BiFunction<IonReader, PageExtractionContext, Integer> callback = callbackFor(decoder, pos);
 
-            if (ionType == IonType.STRUCT && !ionReader.isNullValue()) {
-                rowDecoder.decode(ionReader, blockSelector);
-            }
-            else if (ionType == IonType.STRUCT || ionType == IonType.NULL || !strictPathing) {
-                rowDecoder.appendNulls(blockSelector);
+            String extractionPath = decoderConfig.pathExtractors().get(name);
+            if (extractionPath == null) {
+                extractorBuilder.withSearchPath(List.of(new Text(name)), callback);
             }
             else {
-                throw new TrinoException(StandardErrorCode.GENERIC_USER_ERROR,
-                        "Top-level-value of IonType %s is not valid with strict typing.".formatted(ionType));
+                extractorBuilder.withSearchPath(extractionPath, callback);
             }
+        }
+        PathExtractor<PageExtractionContext> extractor = extractorBuilder.buildStrict(decoderConfig.strictTyping());
+        PageExtractionContext context = new PageExtractionContext(pageBuilder, new boolean[columns.size()]);
+
+        return (ionReader) -> {
+            extractor.matchCurrentValue(ionReader, context);
+            context.completeRowAndReset();
         };
+    }
+
+    private static BiFunction<IonReader, PageExtractionContext, Integer> callbackFor(BlockDecoder decoder, int pos)
+    {
+        return (ionReader, context) -> {
+            BlockBuilder blockBuilder = context.pageBuilder.getBlockBuilder(pos);
+            if (context.encountered[pos]) {
+                blockBuilder.resetTo(blockBuilder.getPositionCount() - 1);
+            }
+            else {
+                context.encountered[pos] = true;
+            }
+
+            decoder.decode(ionReader, context.pageBuilder.getBlockBuilder(pos));
+            return 0;
+        };
+    }
+
+    private record PageExtractionContext(PageBuilder pageBuilder, boolean[] encountered)
+    {
+        private void completeRowAndReset()
+        {
+            for (int i = 0; i < encountered.length; i++) {
+                if (!encountered[i]) {
+                    pageBuilder.getBlockBuilder(i).appendNull();
+                }
+                encountered[i] = false;
+            }
+        }
     }
 
     private interface BlockDecoder
@@ -166,10 +197,6 @@ public class IonDecoderFactory
         };
     }
 
-    /**
-     * The RowDecoder is used as the BlockDecoder for nested RowTypes and is used for decoding
-     * top-level structs into pages.
-     */
     private record RowDecoder(Map<String, Integer> fieldPositions, List<BlockDecoder> fieldDecoders)
             implements BlockDecoder
     {
@@ -220,13 +247,6 @@ public class IonDecoderFactory
             }
 
             ionReader.stepOut();
-        }
-
-        private void appendNulls(IntFunction<BlockBuilder> blockSelector)
-        {
-            for (int i = 0; i < fieldDecoders.size(); i++) {
-                blockSelector.apply(i).appendNull();
-            }
         }
     }
 

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
@@ -19,6 +19,7 @@ import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ion.system.IonSystemBuilder;
+import com.amazon.ionpathextraction.exceptions.PathExtractionException;
 import com.google.common.collect.ImmutableMap;
 import io.trino.hive.formats.line.Column;
 import io.trino.spi.Page;
@@ -48,6 +49,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 
 import static io.trino.hive.formats.FormatTestUtils.assertColumnValuesEquals;
@@ -108,18 +110,20 @@ public class TestIonFormat
             throws IOException
     {
         RowType rowType = RowType.rowType(field("foo", INTEGER), field("bar", VARCHAR));
+        IonDecoderConfig decoderConfig = new IonDecoderConfig(Map.of(), true);
         List<Object> expected = new ArrayList<>(2);
         expected.add(null);
         expected.add(null);
 
         assertValues(rowType,
+                decoderConfig,
                 // empty struct, untyped null, struct null, and explicitly typed null null, phew.
                 "{} null null.struct null.null",
                 expected, expected, expected, expected);
 
-        Assertions.assertThrows(TrinoException.class, () -> {
-            assertValues(rowType, "null.int", expected);
-            assertValues(rowType, "[]", expected);
+        Assertions.assertThrows(PathExtractionException.class, () -> {
+            assertValues(rowType, decoderConfig, "null.int", expected);
+            assertValues(rowType, decoderConfig, "[]", expected);
         });
     }
 
@@ -133,7 +137,6 @@ public class TestIonFormat
         expected.add(null);
 
         assertValues(rowType,
-                false,
                 "{} 37 null.list null.struct null spam false",
                 expected, expected, expected, expected, expected, expected, expected);
     }
@@ -413,6 +416,31 @@ public class TestIonFormat
     }
 
     @Test
+    public void testPathExtraction()
+            throws IOException
+    {
+        Map<String, String> pathExtractions = Map.of("bar", "(foo bar)", "baz", "(foo baz)");
+        assertValues(
+                RowType.rowType(field("qux", BOOLEAN), field("bar", INTEGER), field("baz", VARCHAR)),
+                new IonDecoderConfig(pathExtractions, false),
+                "{ foo: { bar: 31, baz: quux }, qux: true }",
+                List.of(true, 31, "quux"));
+    }
+
+    @Test
+    public void testNonStructTlvPathExtraction()
+            throws IOException
+    {
+        Map<String, String> pathExtractions = Map.of("tlv", "()");
+        assertValues(
+                RowType.rowType(field("tlv", new ArrayType(INTEGER))),
+                new IonDecoderConfig(pathExtractions, false),
+                "[13, 17] [19, 23]",
+                List.of(List.of(13, 17)),
+                List.of(List.of(19, 23)));
+    }
+
+    @Test
     public void testEncode()
             throws IOException
     {
@@ -495,10 +523,10 @@ public class TestIonFormat
     private void assertValues(RowType rowType, String ionText, List<Object>... expected)
             throws IOException
     {
-        assertValues(rowType, true, ionText, expected);
+        assertValues(rowType, IonDecoderConfig.defaultConfig(), ionText, expected);
     }
 
-    private void assertValues(RowType rowType, Boolean strictTlvs, String ionText, List<Object>... expected)
+    private void assertValues(RowType rowType, IonDecoderConfig config, String ionText, List<Object>... expected)
             throws IOException
     {
         List<RowType.Field> fields = rowType.getFields();
@@ -509,14 +537,14 @@ public class TestIonFormat
                     return new Column(field.getName().get(), field.getType(), i);
                 })
                 .toList();
-        IonDecoder decoder = IonDecoderFactory.buildDecoder(columns, strictTlvs);
         PageBuilder pageBuilder = new PageBuilder(expected.length, rowType.getFields().stream().map(RowType.Field::getType).toList());
+        IonDecoder decoder = IonDecoderFactory.buildDecoder(columns, config, pageBuilder);
 
         try (IonReader ionReader = IonReaderBuilder.standard().build(ionText)) {
             for (int i = 0; i < expected.length; i++) {
                 assertThat(ionReader.next()).isNotNull();
                 pageBuilder.declarePosition();
-                decoder.decode(ionReader, pageBuilder);
+                decoder.decode(ionReader);
             }
             assertThat(ionReader.next()).isNull();
         }

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
@@ -110,7 +110,7 @@ public class TestIonFormat
             throws IOException
     {
         RowType rowType = RowType.rowType(field("foo", INTEGER), field("bar", VARCHAR));
-        IonDecoderConfig decoderConfig = new IonDecoderConfig(Map.of(), true);
+        IonDecoderConfig decoderConfig = IonDecoderConfig.defaultConfig().withStrictTyping();
         List<Object> expected = new ArrayList<>(2);
         expected.add(null);
         expected.add(null);
@@ -201,6 +201,20 @@ public class TestIonFormat
                         field("BAR", VARCHAR)),
                 "{ bar: baz, Foo: 31, foo: 5 }",
                 List.of(5, "baz"));
+    }
+
+    @Test
+    public void testCaseSensitiveExtraction()
+            throws IOException
+    {
+        assertValues(
+                RowType.rowType(
+                        field("Foo", INTEGER),
+                        field("Bar", VARCHAR)),
+                IonDecoderConfig.defaultConfig().withCaseSensitive(),
+                // assumes duplicate fields overwrite, which is asserted in the test above
+                "{ Bar: baz, bar: blegh, Foo: 31, foo: 67 }",
+                List.of(31, "baz"));
     }
 
     @Test
@@ -422,7 +436,7 @@ public class TestIonFormat
         Map<String, String> pathExtractions = Map.of("bar", "(foo bar)", "baz", "(foo baz)");
         assertValues(
                 RowType.rowType(field("qux", BOOLEAN), field("bar", INTEGER), field("baz", VARCHAR)),
-                new IonDecoderConfig(pathExtractions, false),
+                IonDecoderConfig.defaultConfig().withPathExtractors(pathExtractions),
                 "{ foo: { bar: 31, baz: quux }, qux: true }",
                 List.of(true, 31, "quux"));
     }
@@ -434,7 +448,7 @@ public class TestIonFormat
         Map<String, String> pathExtractions = Map.of("tlv", "()");
         assertValues(
                 RowType.rowType(field("tlv", new ArrayType(INTEGER))),
-                new IonDecoderConfig(pathExtractions, false),
+                IonDecoderConfig.defaultConfig().withPathExtractors(pathExtractions),
                 "[13, 17] [19, 23]",
                 List.of(List.of(13, 17)),
                 List.of(List.of(19, 23)));
@@ -456,7 +470,7 @@ public class TestIonFormat
 
         assertValues(
                 rowType,
-                new IonDecoderConfig(pathExtractions, true),
+                IonDecoderConfig.defaultConfig().withPathExtractors(pathExtractions),
                 "[13, baz] [17, qux]",
                 List.of(13, "baz"),
                 List.of(17, "qux"));

--- a/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
+++ b/lib/trino-hive-formats/src/test/java/io/trino/hive/formats/ion/TestIonFormat.java
@@ -440,6 +440,28 @@ public class TestIonFormat
                 List.of(List.of(19, 23)));
     }
 
+    /**
+     * Shows how users can configure mapping sequence positions from Ion values to a Trino row.
+     */
+    @Test
+    public void testPositionalPathExtraction()
+            throws IOException
+    {
+        Map<String, String> pathExtractions = Map.of(
+                "foo", "(0)",
+                "bar", "(1)");
+        RowType rowType = RowType.rowType(
+                field("foo", INTEGER),
+                field("bar", VARCHAR));
+
+        assertValues(
+                rowType,
+                new IonDecoderConfig(pathExtractions, true),
+                "[13, baz] [17, qux]",
+                List.of(13, "baz"),
+                List.of(17, "qux"));
+    }
+
     @Test
     public void testEncode()
             throws IOException

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSource.java
@@ -112,7 +112,7 @@ public class IonPageSource
         }
 
         pageBuilder.declarePosition();
-        decoder.decode(ionReader, pageBuilder);
+        decoder.decode(ionReader);
         return true;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonPageSourceFactory.java
@@ -63,8 +63,6 @@ import static io.trino.plugin.hive.ion.IonReaderOptions.FAIL_ON_OVERFLOW_PROPERT
 import static io.trino.plugin.hive.ion.IonReaderOptions.FAIL_ON_OVERFLOW_PROPERTY_WITH_COLUMN;
 import static io.trino.plugin.hive.ion.IonReaderOptions.IGNORE_MALFORMED;
 import static io.trino.plugin.hive.ion.IonReaderOptions.IGNORE_MALFORMED_DEFAULT;
-import static io.trino.plugin.hive.ion.IonReaderOptions.PATH_EXTRACTION_CASE_SENSITIVITY;
-import static io.trino.plugin.hive.ion.IonReaderOptions.PATH_EXTRACTION_CASE_SENSITIVITY_DEFAULT;
 import static io.trino.plugin.hive.ion.IonWriterOptions.ION_SERIALIZATION_AS_NULL_DEFAULT;
 import static io.trino.plugin.hive.ion.IonWriterOptions.ION_SERIALIZATION_AS_NULL_PROPERTY;
 import static io.trino.plugin.hive.ion.IonWriterOptions.ION_SERIALIZATION_AS_PROPERTY;
@@ -82,7 +80,6 @@ public class IonPageSourceFactory
     private static final Map<String, String> TABLE_PROPERTIES = ImmutableMap.of(
             FAIL_ON_OVERFLOW_PROPERTY, FAIL_ON_OVERFLOW_PROPERTY_DEFAULT,
             IGNORE_MALFORMED, IGNORE_MALFORMED_DEFAULT,
-            PATH_EXTRACTION_CASE_SENSITIVITY, PATH_EXTRACTION_CASE_SENSITIVITY_DEFAULT,
             ION_TIMESTAMP_OFFSET_PROPERTY, ION_TIMESTAMP_OFFSET_DEFAULT,
             ION_SERIALIZATION_AS_NULL_PROPERTY, ION_SERIALIZATION_AS_NULL_DEFAULT);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonReaderOptions.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonReaderOptions.java
@@ -50,8 +50,10 @@ public final class IonReaderOptions
 
         Boolean strictTyping = Boolean.parseBoolean(
                 propertiesMap.getOrDefault(STRICT_PATH_TYPING_PROPERTY, STRICT_PATH_TYPING_DEFAULT));
+        Boolean caseSensitive = Boolean.parseBoolean(
+                propertiesMap.getOrDefault(PATH_EXTRACTION_CASE_SENSITIVITY, PATH_EXTRACTION_CASE_SENSITIVITY_DEFAULT));
 
         // n.b.: the hive serde overwrote when there were duplicate extractors defined for a column
-        return new IonDecoderConfig(extractionsBuilder.buildOrThrow(), strictTyping);
+        return new IonDecoderConfig(extractionsBuilder.buildOrThrow(), strictTyping, caseSensitive);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonReaderOptions.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ion/IonReaderOptions.java
@@ -13,13 +13,18 @@
  */
 package io.trino.plugin.hive.ion;
 
+import com.google.common.collect.ImmutableMap;
+import io.trino.hive.formats.ion.IonDecoderConfig;
+
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public final class IonReaderOptions
 {
     public static final String STRICT_PATH_TYPING_PROPERTY = "ion.path_extractor.strict";
     public static final String STRICT_PATH_TYPING_DEFAULT = "false";
-    public static final String PATH_EXTRACTOR_PROPERTY = "ion.\\w+.path_extractor";
+    public static final String PATH_EXTRACTOR_PROPERTY = "ion.(\\w+).path_extractor";
     public static final String PATH_EXTRACTION_CASE_SENSITIVITY = "ion.path_extractor.case_sensitive";
     public static final String PATH_EXTRACTION_CASE_SENSITIVITY_DEFAULT = "false";
     public static final String FAIL_ON_OVERFLOW_PROPERTY_WITH_COLUMN = "ion.\\w+.fail_on_overflow";
@@ -28,11 +33,25 @@ public final class IonReaderOptions
     public static final String IGNORE_MALFORMED = "ion.ignore_malformed";
     public static final String IGNORE_MALFORMED_DEFAULT = "false";
 
+    private static final Pattern pathExtractorPattern = Pattern.compile(PATH_EXTRACTOR_PROPERTY);
+
     private IonReaderOptions() {}
 
-    static boolean useStrictPathTyping(Map<String, String> propertiesMap)
+    public static IonDecoderConfig decoderConfigFor(Map<String, String> propertiesMap)
     {
-        return Boolean.parseBoolean(
+        ImmutableMap.Builder<String, String> extractionsBuilder = ImmutableMap.builder();
+
+        for (Map.Entry<String, String> property : propertiesMap.entrySet()) {
+            Matcher matcher = pathExtractorPattern.matcher(property.getKey());
+            if (matcher.matches()) {
+                extractionsBuilder.put(matcher.group(1), property.getValue());
+            }
+        }
+
+        Boolean strictTyping = Boolean.parseBoolean(
                 propertiesMap.getOrDefault(STRICT_PATH_TYPING_PROPERTY, STRICT_PATH_TYPING_DEFAULT));
+
+        // n.b.: the hive serde overwrote when there were duplicate extractors defined for a column
+        return new IonDecoderConfig(extractionsBuilder.buildOrThrow(), strictTyping);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/ion/IonPageSourceSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/ion/IonPageSourceSmokeTest.java
@@ -67,8 +67,6 @@ import static io.trino.plugin.hive.ion.IonReaderOptions.FAIL_ON_OVERFLOW_PROPERT
 import static io.trino.plugin.hive.ion.IonReaderOptions.FAIL_ON_OVERFLOW_PROPERTY_DEFAULT;
 import static io.trino.plugin.hive.ion.IonReaderOptions.IGNORE_MALFORMED;
 import static io.trino.plugin.hive.ion.IonReaderOptions.IGNORE_MALFORMED_DEFAULT;
-import static io.trino.plugin.hive.ion.IonReaderOptions.PATH_EXTRACTION_CASE_SENSITIVITY;
-import static io.trino.plugin.hive.ion.IonReaderOptions.PATH_EXTRACTION_CASE_SENSITIVITY_DEFAULT;
 import static io.trino.plugin.hive.ion.IonWriterOptions.BINARY_ENCODING;
 import static io.trino.plugin.hive.ion.IonWriterOptions.ION_ENCODING_PROPERTY;
 import static io.trino.plugin.hive.ion.IonWriterOptions.ION_SERIALIZATION_AS_NULL_DEFAULT;
@@ -155,6 +153,17 @@ public class IonPageSourceSmokeTest
     }
 
     @Test
+    public void testCaseSensitive()
+            throws IOException
+    {
+        TestFixture fixture = new TestFixture(List.of(toHiveBaseColumnHandle("bar", INTEGER, 0)))
+                .withSerdeProperty("ion.path_extractor.case_sensitive", "true");
+
+        // this would result in errors if we tried to extract the BAR field
+        fixture.assertRowCount("{ BAR: should_be_skipped } { bar: 17 }", 2);
+    }
+
+    @Test
     public void testProjectedColumn()
             throws IOException
     {
@@ -191,7 +200,6 @@ public class IonPageSourceSmokeTest
     {
         return Stream.of(
                 entry(FAIL_ON_OVERFLOW_PROPERTY, FAIL_ON_OVERFLOW_PROPERTY_DEFAULT),
-                entry(PATH_EXTRACTION_CASE_SENSITIVITY, PATH_EXTRACTION_CASE_SENSITIVITY_DEFAULT),
                 entry(IGNORE_MALFORMED, IGNORE_MALFORMED_DEFAULT),
                 entry(ION_TIMESTAMP_OFFSET_PROPERTY, ION_TIMESTAMP_OFFSET_DEFAULT),
                 entry(ION_SERIALIZATION_AS_NULL_PROPERTY, ION_SERIALIZATION_AS_NULL_DEFAULT));
@@ -201,7 +209,6 @@ public class IonPageSourceSmokeTest
     {
         return Stream.of(
                 entry(FAIL_ON_OVERFLOW_PROPERTY, "false"),
-                entry(PATH_EXTRACTION_CASE_SENSITIVITY, "true"),
                 entry(IGNORE_MALFORMED, "true"),
                 entry(ION_TIMESTAMP_OFFSET_PROPERTY, "01:00"),
                 entry(ION_SERIALIZATION_AS_NULL_PROPERTY, "TYPED"),


### PR DESCRIPTION
This change implements support for path extraction SerDe Properties.
It uses the same ion-java-path-extraction library the Ion Hive SerDe
does. Unlike the Hive SerDe, this ensures that the "strict" and more
performant path extraction implementation is used.

I chose to use the path-extraction in the absence of any defined path
extractors. When a path extractor is defined, you have to define all
columns as extractions. With the strict implementation, the field lookup
is effectively the same as the Decoder here. So given that I would
rather cut modality unless there's a really compelling reason.

I also chose to implement support for the case-sensitive flag. I didn't 
find evidence it _is_ used, but it seems like a reasonable use of path-
extraction (disambiguate bad data). And the cost of doing it now is low
whereas the cost of hitting a need and adding it later seems painful.